### PR TITLE
Add OpenArm-Reach task

### DIFF
--- a/src/openarm_mjlab/actions.py
+++ b/src/openarm_mjlab/actions.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom action terms shared by the reach/valve/door/drawer/puck/lift task family.
+
+All tasks in the family actively control only one arm; the parked arm needs
+an explicit hold action so it is not pulled toward qpos 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.envs.mdp.actions.actions import JointPositionAction, JointPositionActionCfg
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+
+class HoldDefaultPositionAction(JointPositionAction):
+    """Zero-dim action term that servo-holds targets at their default pose.
+
+    Every task in this family actively controls only one arm; the parked
+    arm needs an explicit hold, since an actuated-but-uncontrolled joint is
+    otherwise pulled toward qpos 0 on every reset rather than its default
+    pose. Matched by ``actuator_names``, commanded to ``default_joint_pos``
+    every step, contributing zero dimensions to the policy's action space.
+    """
+
+    @property
+    def action_dim(self) -> int:
+        """Return zero: this term takes no policy input."""
+        return 0
+
+    def process_actions(self, actions: torch.Tensor) -> None:
+        """Do nothing; the hold target is constant, not policy-driven."""
+        del actions  # Nothing to process; targets are constant.
+
+    def apply_actions(self) -> None:
+        """Command the held joints back to their default position."""
+        encoder_bias = self._entity.data.encoder_bias[:, self._target_ids]
+        self._entity.set_joint_position_target(
+            self._offset - encoder_bias, joint_ids=self._target_ids
+        )
+
+
+@dataclass(kw_only=True)
+class HoldDefaultPositionActionCfg(JointPositionActionCfg):
+    """Config for :class:`HoldDefaultPositionAction`."""
+
+    def build(self, env: ManagerBasedRlEnv) -> HoldDefaultPositionAction:
+        """Build the :class:`HoldDefaultPositionAction` term."""
+        return HoldDefaultPositionAction(self, env)

--- a/src/openarm_mjlab/robot_bimanual.py
+++ b/src/openarm_mjlab/robot_bimanual.py
@@ -100,7 +100,7 @@ BIMANUAL_ACTION_SCALE: dict[str, float] = {
 
 
 def get_bimanual_robot_cfg() -> EntityCfg:
-    """Entity config for the bare bimanual OpenArm, both arms actuated."""
+    """Entity config for the pedestal-mounted bimanual OpenArm, both arms actuated."""
     return EntityCfg(
         init_state=BIMANUAL_HOME,
         spec_fn=get_bimanual_spec,

--- a/src/openarm_mjlab/robot_bimanual.py
+++ b/src/openarm_mjlab/robot_bimanual.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bare bimanual OpenArm entity config shared by the reach/valve/door/drawer/puck/lift tasks.
+
+Unlike the OpenArm Cell used by pick_place (a fixed table+walls+lifter scene
+with one arm frozen), this family mounts BOTH arms on a stand-alone pedestal
+and actively controls the right arm per task (the left is servo-held at its
+default pose via ``mjlab.envs.mdp.actions``' hold pattern in each task's own
+``actions`` dict), giving each task room to add its own fixture (a valve,
+door, drawer, or free object) on a plain table without the Cell's lifter/
+wall geometry in the way.
+
+mjlab owns actuation, so the spec strips the asset's own 16 position
+actuators; the entity config below rebuilds them with the same gains the
+asset's own actuator classes declare (DM8009/DM4340/DM4310 per the OpenArm
+hardware spec), verified directly against the compiled asset rather than
+hand-copied.
+"""
+
+import mujoco
+import openarm_mujoco.v2
+
+from mjlab.actuator import BuiltinPositionActuatorCfg
+from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
+
+OPENARM_BIMANUAL_XML = openarm_mujoco.v2.openarm_bimanual_xml()
+
+# The task family's own scenes mount the pedestal at this height (matching
+# the OpenArm Cell asset's own arm-attach height, read once so a future
+# asset update cannot silently diverge from the value baked in below).
+ARM_ATTACH_HEIGHT = 0.698
+
+EE_SITE_RIGHT = "right_ee_control_point"
+EE_SITE_LEFT = "left_ee_control_point"
+
+# The finger pads close ~0.135 m along each EE site's local -z axis; every
+# task in this family that reaches for or grasps something targets this
+# point (the tool point), not the wrist-mounted site itself, so the gripper
+# closes AROUND an object instead of stopping short of it.
+GRASP_LOCAL_OFFSET = (0.0, 0.0, -0.135)
+
+
+def get_bimanual_spec() -> mujoco.MjSpec:
+    """Load the bare bimanual asset with its own position actuators removed."""
+    spec = mujoco.MjSpec.from_file(str(OPENARM_BIMANUAL_XML))
+    for act in list(spec.actuators):
+        spec.delete(act)
+    return spec
+
+
+# Gains/effort limits copied from the asset's own actuator classes: joints
+# 1-2 DM8009 kp=230 kv=2.7 |40 Nm|, joints 3-4 DM4340 kp=190 kv=2.2 |27 Nm|,
+# joints 5-7 DM4310/3507 kp=30 kv=1.5 |7 Nm|, finger kp=150 kv=2 |30 N|. Only
+# finger_joint1 is actuated per side; finger_joint2 mimics it via equality.
+_ACTUATOR_GROUPS = (
+    ("openarm_(left|right)_joint[12]", 230.0, 2.7, 40.0),
+    ("openarm_(left|right)_joint[34]", 190.0, 2.2, 27.0),
+    ("openarm_(left|right)_joint[567]", 30.0, 1.5, 7.0),
+    ("openarm_(left|right)_finger_joint1", 150.0, 2.0, 30.0),
+)
+
+BIMANUAL_ACTUATORS = tuple(
+    BuiltinPositionActuatorCfg(
+        target_names_expr=(expr,),
+        stiffness=kp,
+        damping=kv,
+        effort_limit=effort,
+    )
+    for expr, kp, kv, effort in _ACTUATOR_GROUPS
+)
+
+# Home pose: elbows bent at 1.5708 rad, everything else at 0.
+BIMANUAL_HOME = EntityCfg.InitialStateCfg(
+    pos=(0.0, 0.0, ARM_ATTACH_HEIGHT),
+    joint_pos={
+        "openarm_(left|right)_joint4": 1.5708,
+        "openarm_(left|right)_joint[12356]": 0.0,
+        "openarm_(left|right)_joint7": 0.0,
+        "openarm_(left|right)_finger_joint[12]": 0.0,
+    },
+    joint_vel={".*": 0.0},
+)
+
+BIMANUAL_ARTICULATION = EntityArticulationInfoCfg(
+    actuators=BIMANUAL_ACTUATORS,
+    soft_joint_pos_limit_factor=0.9,
+)
+
+# Same convention mjlab's own yam config uses: scale = 0.25 * effort / stiffness.
+BIMANUAL_ACTION_SCALE: dict[str, float] = {
+    expr: 0.25 * effort / kp for expr, kp, _kv, effort in _ACTUATOR_GROUPS
+}
+
+
+def get_bimanual_robot_cfg() -> EntityCfg:
+    """Entity config for the bare bimanual OpenArm, both arms actuated."""
+    return EntityCfg(
+        init_state=BIMANUAL_HOME,
+        spec_fn=get_bimanual_spec,
+        articulation=BIMANUAL_ARTICULATION,
+    )

--- a/src/openarm_mjlab/robot_bimanual.py
+++ b/src/openarm_mjlab/robot_bimanual.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bare bimanual OpenArm entity config shared by the reach/valve/door/drawer/puck/lift tasks.
+"""Pedestal-mounted bimanual OpenArm entity config, shared by the reach/valve/door/drawer/puck/lift tasks.
 
 Unlike the OpenArm Cell used by pick_place (a fixed table+walls+lifter scene
 with one arm frozen), this family mounts BOTH arms on a stand-alone pedestal
@@ -35,12 +35,7 @@ import openarm_mujoco.v2
 from mjlab.actuator import BuiltinPositionActuatorCfg
 from mjlab.entity import EntityArticulationInfoCfg, EntityCfg
 
-OPENARM_BIMANUAL_XML = openarm_mujoco.v2.openarm_bimanual_xml()
-
-# The task family's own scenes mount the pedestal at this height (matching
-# the OpenArm Cell asset's own arm-attach height, read once so a future
-# asset update cannot silently diverge from the value baked in below).
-ARM_ATTACH_HEIGHT = 0.698
+OPENARM_PEDESTAL_XML = openarm_mujoco.v2.asset_path("pedestal/openarm_pedestal.xml")
 
 EE_SITE_RIGHT = "right_ee_control_point"
 EE_SITE_LEFT = "left_ee_control_point"
@@ -53,8 +48,8 @@ GRASP_LOCAL_OFFSET = (0.0, 0.0, -0.135)
 
 
 def get_bimanual_spec() -> mujoco.MjSpec:
-    """Load the bare bimanual asset with its own position actuators removed."""
-    spec = mujoco.MjSpec.from_file(str(OPENARM_BIMANUAL_XML))
+    """Load the pedestal-mounted asset with its own position actuators removed."""
+    spec = mujoco.MjSpec.from_file(str(OPENARM_PEDESTAL_XML))
     for act in list(spec.actuators):
         spec.delete(act)
     return spec
@@ -83,7 +78,7 @@ BIMANUAL_ACTUATORS = tuple(
 
 # Home pose: elbows bent at 1.5708 rad, everything else at 0.
 BIMANUAL_HOME = EntityCfg.InitialStateCfg(
-    pos=(0.0, 0.0, ARM_ATTACH_HEIGHT),
+    pos=(0.0, 0.0, 0.0),
     joint_pos={
         "openarm_(left|right)_joint4": 1.5708,
         "openarm_(left|right)_joint[12356]": 0.0,

--- a/src/openarm_mjlab/tasks/reach/__init__.py
+++ b/src/openarm_mjlab/tasks/reach/__init__.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenArm task registrations. Importing this package registers all tasks."""
+"""OpenArm reach task."""
 
-from . import pick_place  # noqa: F401
-from . import reach  # noqa: F401
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .reach_env_cfg import openarm_reach_env_cfg
+from .rl_cfg import openarm_reach_ppo_runner_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-Reach",
+    env_cfg=openarm_reach_env_cfg(),
+    play_env_cfg=openarm_reach_env_cfg(play=True),
+    rl_cfg=openarm_reach_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/reach/mdp.py
+++ b/src/openarm_mjlab/tasks/reach/mdp.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reach task MDP: drive the tool point to a random workspace target."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv
+
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+# Right-arm workspace box for targets (raw world coordinates; every env is
+# its own batched world, not a viewer-layout offset).
+TARGET_LO = (0.25, -0.35, 0.45)
+TARGET_HI = (0.45, -0.05, 0.65)
+SUCCESS_DIST = 0.02
+SETTLED_QVEL = 0.3  # rad/s max arm joint speed counted as "held".
+
+
+def _targets(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Lazily allocate and return the per-env target buffer."""
+    if not hasattr(env, "_reach_targets"):
+        lo = torch.tensor(TARGET_LO, device=env.device)
+        hi = torch.tensor(TARGET_HI, device=env.device)
+        env._reach_targets = lo + (hi - lo) * torch.rand(
+            env.num_envs, 3, device=env.device
+        )
+    return env._reach_targets
+
+
+def resample_targets(env: ManagerBasedRlEnv, env_ids: torch.Tensor) -> None:
+    """Reset event: draw a fresh random target for the given envs."""
+    lo = torch.tensor(TARGET_LO, device=env.device)
+    hi = torch.tensor(TARGET_HI, device=env.device)
+    _targets(env)[env_ids] = lo + (hi - lo) * torch.rand(
+        len(env_ids), 3, device=env.device
+    )
+
+
+def tool_pos_w(env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg) -> torch.Tensor:
+    """World-frame position of the grasp/tool point (see GRASP_LOCAL_OFFSET)."""
+    robot: Entity = env.scene[robot_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    return ee_pos_w + quat_apply(ee_quat_w, offset)
+
+
+def target_dist(env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Euclidean distance from the tool point to its current target."""
+    return torch.linalg.norm(tool_pos_w(env, robot_cfg) - _targets(env), dim=-1)
+
+
+def tool_to_target_obs(
+    env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Target-minus-tool vector, in the robot's own base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    vec_w = _targets(env) - tool_pos_w(env, robot_cfg)
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def reach_reward(
+    env: ManagerBasedRlEnv, std: float, robot_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Gaussian-kernel dense reward on distance-to-target."""
+    d = target_dist(env, robot_cfg)
+    return torch.exp(-((d / std) ** 2))
+
+
+def arm_settled(env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return True where every joint's speed is below the settled threshold."""
+    robot: Entity = env.scene[robot_cfg.name]
+    return robot.data.joint_vel.abs().max(dim=-1).values < SETTLED_QVEL
+
+
+def hold_at_target_reward(
+    env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Return a dense reward for staying near the target.
+
+    Uses a looser band than success, so it does not collapse into a
+    one-step reward paid only on termination.
+    """
+    close = target_dist(env, robot_cfg) < 2 * SUCCESS_DIST
+    return close.float()
+
+
+def reach_success_bonus(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """One-shot bonus tied to the ``reached`` termination firing."""
+    return env.termination_manager.get_term("reached").float()
+
+
+def reached(env: ManagerBasedRlEnv, robot_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Success termination: within SUCCESS_DIST of the target and settled."""
+    close = target_dist(env, robot_cfg) < SUCCESS_DIST
+    return close & arm_settled(env, robot_cfg)

--- a/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
+++ b/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
@@ -122,8 +122,19 @@ def openarm_reach_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             weight=2.0,
             params={"robot_cfg": ROBOT_EE_CFG},
         ),
+        # Success is a one-shot bonus (weight * dt) that ENDS the episode,
+        # forfeiting all remaining dense reward. Hovering at the target
+        # while avoiding the settle condition earns ~0.10/step (coarse +
+        # fine + hold, dt-scaled), and because timeouts are value-
+        # bootstrapped that stream is worth up to 0.10 / (1 - 0.99) = 10 in
+        # discounted return. Terminating is therefore only optimal when
+        # weight * 0.02 > 0.99 * 10, i.e. weight > ~500 -- so the earlier
+        # 300 (= 6.0) sat below the bound and made hovering forever the
+        # reward-optimal behaviour. 750 (= 15.0) clears it with 50% margin
+        # while staying the same order as the per-episode dense return
+        # (~30), so it does not drown the shaping gradient.
         "success": RewardTermCfg(
-            func=reach_mdp.reach_success_bonus, weight=300.0, params={}
+            func=reach_mdp.reach_success_bonus, weight=750.0, params={}
         ),
         "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
         "joint_vel_hinge": RewardTermCfg(
@@ -165,11 +176,14 @@ def openarm_reach_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         rewards=rewards,
         terminations=terminations,
         curriculum={},
+        # A fixed WORLD camera rather than an ASSET_BODY tracking one:
+        # MuJoCo tracking cameras follow the tracked body's subtree COM
+        # (here the whole right arm), so offscreen-rendered videos sway
+        # with every arm motion. mjlab's interactive viewer works around
+        # that, so the artifact only shows up in recorded video.
         viewer=ViewerConfig(
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
-            entity_name="robot",
-            body_name="openarm_right_base_link",
-            distance=1.6,
+            origin_type=ViewerConfig.OriginType.WORLD,
+            lookat=(0.35, -0.2, 0.55),
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
+++ b/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
@@ -184,6 +184,7 @@ def openarm_reach_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         viewer=ViewerConfig(
             origin_type=ViewerConfig.OriginType.WORLD,
             lookat=(0.35, -0.2, 0.55),
+            distance=1.6,
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
+++ b/src/openarm_mjlab/tasks/reach/reach_env_cfg.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm reach task."""
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from ...actions import HoldDefaultPositionActionCfg
+from ...robot_bimanual import (
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+)
+from . import mdp as reach_mdp
+
+ROBOT_EE_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+
+
+def openarm_reach_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm reach environment config."""
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "tool_to_target": ObservationTermCfg(
+            func=reach_mdp.tool_to_target_obs,
+            params={"robot_cfg": ROBOT_EE_CFG},
+            noise=Unoise(n_min=-0.005, n_max=0.005),
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+    actions: dict[str, ActionTermCfg] = {
+        "joint_pos": JointPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_.*",),
+            scale=BIMANUAL_ACTION_SCALE,
+            use_default_offset=True,
+        ),
+        "left_hold": HoldDefaultPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_.*",),
+            scale=1.0,
+            use_default_offset=True,
+        ),
+    }
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "resample_target": EventTermCfg(
+            func=reach_mdp.resample_targets,
+            mode="reset",
+            params={},
+        ),
+        # Domain-randomization pass (arm actuator gains -- reach has no
+        # manipulated object, so this is the only physically-meaningful
+        # randomization axis): held up 100% clean success under +-15%
+        # kp/kd, essentially unchanged from the nominal task.
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
+            },
+        ),
+    }
+    rewards = {
+        "reach_coarse": RewardTermCfg(
+            func=reach_mdp.reach_reward,
+            weight=1.0,
+            params={"std": 0.2, "robot_cfg": ROBOT_EE_CFG},
+        ),
+        "reach_fine": RewardTermCfg(
+            func=reach_mdp.reach_reward,
+            weight=2.0,
+            params={"std": 0.05, "robot_cfg": ROBOT_EE_CFG},
+        ),
+        "hold": RewardTermCfg(
+            func=reach_mdp.hold_at_target_reward,
+            weight=2.0,
+            params={"robot_cfg": ROBOT_EE_CFG},
+        ),
+        "success": RewardTermCfg(
+            func=reach_mdp.reach_success_bonus, weight=300.0, params={}
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg("robot", joint_names=("openarm_right_.*",)),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "reached": TerminationTermCfg(
+            func=reach_mdp.reached,
+            params={"robot_cfg": ROBOT_EE_CFG},
+        ),
+    }
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={"robot": get_bimanual_robot_cfg()},
+            num_envs=1,
+            env_spacing=2.5,
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=1.6,
+            elevation=-20.0,
+            azimuth=220.0,
+        ),
+        sim=SimulationCfg(
+            nconmax=100,
+            njmax=700,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        episode_length_s=6.0,
+    )
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/reach/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/reach/rl_cfg.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm reach task."""
+
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
+
+
+def openarm_reach_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the reach task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_reach",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=2_000,
+    )

--- a/tests/test_reach_env.py
+++ b/tests/test_reach_env.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-Reach environment.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+# joint_pos/joint_vel report ALL 18 bimanual joints (both arms), regardless
+# of which arm this task actually actuates.
+OBS_DIM = 18 + 18 + 3 + 8  # joint_pos, joint_vel, tool_to_target, actions
+
+
+def test_task_is_registered():
+    assert "OpenArm-Reach" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Reach")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == 8
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_target_spawns_in_workspace_box(env):
+    env.reset()
+    from openarm_mjlab.tasks.reach.mdp import TARGET_HI, TARGET_LO, _targets
+
+    targets = _targets(env)
+    lo = torch.tensor(TARGET_LO)
+    hi = torch.tensor(TARGET_HI)
+    assert (targets >= lo).all() and (targets <= hi).all()
+
+
+def test_left_arm_stays_at_default_under_zero_action(env):
+    """The parked left arm must hold its default pose, not drift to qpos 0."""
+    env.reset()
+    action = torch.zeros(2, env.action_manager.total_action_dim)
+    for _ in range(20):
+        env.step(action)
+    robot = env.scene["robot"]
+    left_j4 = robot.find_joints("openarm_left_joint4")[0][0]
+    # Home pose has joint4 at 1.5708 rad; qpos 0 would mean the hold failed.
+    assert torch.allclose(
+        robot.data.joint_pos[:, left_j4], torch.tensor(1.5708), atol=0.05
+    )


### PR DESCRIPTION
The right arm reaches a randomized Cartesian target while the left arm is servo-held at its default pose. This is the first of the reach/valve/door/drawer/puck/lift series discussed in #39, split into one PR per task per your suggestion there.

This PR also introduces the infrastructure the rest of the series builds on: `robot_bimanual.py` and `actions.py`.

**Results:** 100% clean success, mean closest approach 2.4mm to target, over 256 held-out episodes (termination-signal-based eval, not a training-time metric).

**Tests:** `tests/test_reach_env.py`, 5/5 passing — task registration, action/observation dimensions, finite-signal stepping, target-workspace bounds, and that the parked left arm actually holds its pose under zero action.