### PR TITLE
Add OpenArm-Valve task

### DIFF
--- a/src/openarm_mjlab/common_mdp.py
+++ b/src/openarm_mjlab/common_mdp.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MDP helper functions shared across the valve/door/drawer/puck/lift tasks.
+
+All of them gate progress on genuine finger-pad contact rather than a proxy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+
+def fingers_on_handle(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return True where a finger pad touches the handle/grip.
+
+    Any-pad contact, not a two-pad pinch: this gripper's closed cage leaves
+    a real gap for slim handles, so even a scripted approach caging the
+    handle presses only one pad against it. Progress rewards are gated on
+    this (sustained contact required, a flick loses contact and forfeits
+    every later step) rather than on the pinch itself.
+    """
+    sensor = env.scene[sensor_name]
+    found = sensor.data.found
+    assert found is not None
+    return (found.view(env.num_envs, -1) > 0).any(dim=1)
+
+
+def fingers_on_handle_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Observation wrapper for :func:`fingers_on_handle`."""
+    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
+
+
+def both_pads_on_block(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return True where BOTH finger pads touch the object.
+
+    A genuine squeeze, not a poke. Used by tasks whose object is wide enough
+    for a real friction pinch (unlike a slim handle bar).
+    """
+    sensor = env.scene[sensor_name]
+    found = sensor.data.found
+    assert found is not None
+    return (found.view(env.num_envs, 2, -1).amax(dim=-1) > 0).all(dim=1)
+
+
+def pinch_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Observation wrapper for :func:`both_pads_on_block`."""
+    return both_pads_on_block(env, sensor_name).float().unsqueeze(-1)

--- a/src/openarm_mjlab/tasks/valve/__init__.py
+++ b/src/openarm_mjlab/tasks/valve/__init__.py
@@ -12,8 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenArm task registrations. Importing this package registers all tasks."""
+"""OpenArm valve-turning task."""
 
-from . import pick_place  # noqa: F401
-from . import reach  # noqa: F401
-from . import valve  # noqa: F401
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .rl_cfg import openarm_valve_ppo_runner_cfg
+from .valve_env_cfg import openarm_valve_env_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-Valve",
+    env_cfg=openarm_valve_env_cfg(),
+    play_env_cfg=openarm_valve_env_cfg(play=True),
+    rl_cfg=openarm_valve_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/valve/mdp.py
+++ b/src/openarm_mjlab/tasks/valve/mdp.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Valve-turning MDP terms.
+
+Contact-gated RATE reward (state rewards pay retroactively), gained progress
+vs. episode start (a randomized start would otherwise pay free income),
+anti-reverse penalty (no pumping), and a terminal success bonus (a success
+termination without one makes the optimum avoid success).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv
+
+from ...common_mdp import fingers_on_handle
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+TARGET_TURN = 1.35  # rad (77.4 deg): the single-grasp kinematic ceiling.
+MAX_TURN_RATE = 1.0  # rad/s
+
+
+def valve_angle(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the valve hinge angle, radians."""
+    valve: Entity = env.scene[asset_cfg.name]
+    return valve.data.joint_pos[:, asset_cfg.joint_ids].squeeze(-1)
+
+
+def valve_rate(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the valve hinge angular velocity, rad/s."""
+    valve: Entity = env.scene[asset_cfg.name]
+    return valve.data.joint_vel[:, asset_cfg.joint_ids].squeeze(-1)
+
+
+def _start_angle(env) -> torch.Tensor:
+    """Return the per-env angle recorded at episode start."""
+    if not hasattr(env, "_valve_start_angle"):
+        env._valve_start_angle = torch.zeros(env.num_envs, device=env.device)
+    return env._valve_start_angle
+
+
+def _gained_contact(env) -> torch.Tensor:
+    """Return rotation accumulated only while fingers touch the grip."""
+    if not hasattr(env, "_valve_gained_contact"):
+        env._valve_gained_contact = torch.zeros(env.num_envs, device=env.device)
+    return env._valve_gained_contact
+
+
+def _max_angle(env, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the per-env running-max angle reached this episode."""
+    if not hasattr(env, "_valve_max_angle"):
+        env._valve_max_angle = valve_angle(env, asset_cfg).clone()
+    return env._valve_max_angle
+
+
+def _prev_progress(env) -> torch.Tensor:
+    """Return the previous step's clamped progress fraction, for shaping."""
+    if not hasattr(env, "_valve_prev_progress"):
+        env._valve_prev_progress = torch.zeros(env.num_envs, device=env.device)
+    return env._valve_prev_progress
+
+
+def record_valve_start(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+) -> None:
+    """Reset all per-episode valve bookkeeping for the given envs."""
+    a = valve_angle(env, asset_cfg)
+    _start_angle(env)[env_ids] = a[env_ids]
+    _gained_contact(env)[env_ids] = 0.0
+    _max_angle(env, asset_cfg)[env_ids] = a[env_ids]
+    _prev_progress(env)[env_ids] = 0.0
+
+
+def turn_gained(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return rotation gained past the episode start (positive direction), rad."""
+    return torch.clamp(valve_angle(env, asset_cfg) - _start_angle(env), min=0.0)
+
+
+def ee_to_grip(
+    env: ManagerBasedRlEnv,
+    robot_cfg: SceneEntityCfg,
+    valve_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the finger-cage center to the valve grip, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    valve: Entity = env.scene[valve_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    tool_pos_w = ee_pos_w + quat_apply(ee_quat_w, offset)
+    grip_pos_w = valve.data.site_pos_w[:, valve_cfg.site_ids].squeeze(1)
+    vec_w = grip_pos_w - tool_pos_w
+    base_quat_w = robot.data.root_link_quat_w
+    return quat_apply(quat_inv(base_quat_w), vec_w)
+
+
+def reach_grip_reward(
+    env: ManagerBasedRlEnv,
+    std: float,
+    robot_cfg: SceneEntityCfg,
+    valve_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a Gaussian-shaped reward on distance from the tool to the grip."""
+    d2 = torch.sum(torch.square(ee_to_grip(env, robot_cfg, valve_cfg)), dim=-1)
+    return torch.exp(-d2 / std**2)
+
+
+def grip_contact_reward(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return a dense reward for holding the grip in contact."""
+    return fingers_on_handle(env, sensor_name).float()
+
+
+def grip_contact_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return the observation wrapper for grip contact."""
+    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
+
+
+def turn_rate_reward(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a contact-gated reward for new angle above the running max.
+
+    Also accumulates gained-under-contact for the honesty check in
+    :func:`turned_target`. Credited progress is capped at ``TARGET_TURN`` so
+    continuing to turn past the target under contact is never separately
+    incentivized once the target is already met.
+    """
+    contact = fingers_on_handle(env, sensor_name).float()
+    a = valve_angle(env, asset_cfg)
+    maxa = _max_angle(env, asset_cfg)
+    a_capped = torch.clamp(a, max=TARGET_TURN)
+    maxa_capped = torch.clamp(maxa, max=TARGET_TURN)
+    new = torch.clamp(a_capped - maxa_capped, min=0.0)
+    new_uncapped = torch.clamp(a - maxa, min=0.0)
+    _gained_contact(env).add_(new_uncapped * contact)
+    maxa.copy_(torch.maximum(maxa, a))
+    capped = torch.clamp(new / env.step_dt, 0.0, MAX_TURN_RATE) / MAX_TURN_RATE
+    return capped * contact
+
+
+def turn_progress_shaping_reward(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+    gamma: float = 0.99,
+) -> torch.Tensor:
+    """Return potential-based shaping (Ng, Harada & Russell 1999) on gained-turn fraction.
+
+    ``reward = gamma * Phi(s') - Phi(s)``. Camping-negative by construction: a
+    fixed state pays ``(gamma - 1) * Phi < 0`` every step instead of paying
+    nothing-or-positive, so holding still under contact is never free.
+    """
+    gate = fingers_on_handle(env, sensor_name).float()
+    cur = torch.clamp(turn_gained(env, asset_cfg) / TARGET_TURN, 0.0, 1.0)
+    prev = _prev_progress(env)
+    shaping = gamma * cur - prev
+    prev.copy_(cur)
+    return shaping * gate
+
+
+def reverse_rate_penalty(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return an anti-pump penalty: backing the valve up is never free."""
+    return torch.clamp(-valve_rate(env, asset_cfg), min=0.0)
+
+
+def overspeed_penalty(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a penalty for turning faster than ``MAX_TURN_RATE``."""
+    return torch.clamp(valve_rate(env, asset_cfg).abs() - MAX_TURN_RATE, min=0.0)
+
+
+def turn_success_bonus(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Fire exactly once, on the success-termination step."""
+    return env.termination_manager.get_term("turned_target").float()
+
+
+def turned_target(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return success: target rotation gained, quasi-static, still in contact.
+
+    Requires at least 85% of the gained turn to have been produced under
+    contact, so a policy that flings the valve open without a real grip does
+    not count as success.
+    """
+    done = turn_gained(env, asset_cfg) >= TARGET_TURN
+    honest = _gained_contact(env) >= 0.85 * TARGET_TURN
+    slow = valve_rate(env, asset_cfg).abs() < MAX_TURN_RATE
+    return done & honest & slow & fingers_on_handle(env, sensor_name)

--- a/src/openarm_mjlab/tasks/valve/mdp.py
+++ b/src/openarm_mjlab/tasks/valve/mdp.py
@@ -133,11 +133,6 @@ def grip_contact_reward(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tenso
     return fingers_on_handle(env, sensor_name).float()
 
 
-def grip_contact_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
-    """Return the observation wrapper for grip contact."""
-    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
-
-
 def turn_rate_reward(
     env: ManagerBasedRlEnv,
     sensor_name: str,

--- a/src/openarm_mjlab/tasks/valve/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/rl_cfg.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm valve-turning task."""
+
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
+
+
+def openarm_valve_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the valve task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_valve",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=2_000,
+    )

--- a/src/openarm_mjlab/tasks/valve/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/rl_cfg.py
@@ -52,5 +52,5 @@ def openarm_valve_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
         experiment_name="openarm_valve",
         save_interval=100,
         num_steps_per_env=24,
-        max_iterations=2_000,
+        max_iterations=3_000,
     )

--- a/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
@@ -351,6 +351,7 @@ def openarm_valve_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         viewer=ViewerConfig(
             origin_type=ViewerConfig.OriginType.WORLD,
             lookat=(0.30, 0.0, 0.52),
+            distance=1.6,
             elevation=-20.0,
             azimuth=200.0,
         ),

--- a/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
@@ -45,6 +45,7 @@ from ...robot_bimanual import (
     EE_SITE_RIGHT,
     get_bimanual_robot_cfg,
 )
+from ...common_mdp import fingers_on_handle_obs
 from . import mdp as valve_mdp
 
 VALVE_POS = (0.25, 0.0, 0.40)
@@ -152,7 +153,7 @@ def openarm_valve_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             noise=Unoise(n_min=-0.01, n_max=0.01),
         ),
         "grip_contact": ObservationTermCfg(
-            func=valve_mdp.grip_contact_obs,
+            func=fingers_on_handle_obs,
             params={"sensor_name": "finger_grip_contact"},
         ),
         "actions": ObservationTermCfg(func=base_mdp.last_action),

--- a/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm valve-turning task.
+
+Fixture geometry: pipe base, hinged hub + lever, vertical grip cylinder at
+the lever tip. A rotary task, so the arm-branch depth wall that constrains
+the drawer task does not apply here.
+"""
+
+import mujoco
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from ...actions import HoldDefaultPositionActionCfg
+from ...robot_bimanual import (
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+)
+from . import mdp as valve_mdp
+
+VALVE_POS = (0.25, 0.0, 0.40)
+_TABLE_REL_POS = (0.47 - VALVE_POS[0], 0.0, 0.36 - VALVE_POS[2])
+
+
+def get_valve_spec() -> mujoco.MjSpec:
+    """Build the pipe + hinged-lever valve fixture spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "valve_fixture"
+    # Programmatic MjSpec defaults to degrees: without this, the hinge
+    # range (-3, 3) compiles to +-3 degrees, not +-3 rad.
+    spec.compiler.degree = False
+
+    base = spec.worldbody.add_body(name="valve_base")
+    base.add_geom(
+        name="table_top",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.41, 0.55, 0.04),
+        pos=_TABLE_REL_POS,
+        rgba=(0.82, 0.71, 0.55, 1.0),
+        friction=(1.0, 0.005, 0.0001),
+    )
+    base.add_geom(
+        name="valve_pipe",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        size=(0.015, 0.0275, 0),
+        pos=(0, 0, 0.0275),
+        rgba=(0.4, 0.4, 0.45, 1.0),
+        friction=(1.0, 0.01, 0.01),
+    )
+
+    valve = base.add_body(name="valve", pos=(0, 0, 0.065))
+    valve.add_joint(
+        name="valve_turn",
+        type=mujoco.mjtJoint.mjJNT_HINGE,
+        axis=(0, 0, 1),
+        range=(-3.0, 3.0),
+        damping=0.5,
+        frictionloss=0.05,
+    )
+    valve.add_geom(
+        name="valve_hub",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        fromto=(0, 0, -0.006, 0, 0, 0.006),
+        size=(0.014, 0, 0),
+        mass=0.05,
+        rgba=(0.3, 0.3, 0.35, 1.0),
+    )
+    valve.add_geom(
+        name="valve_lever",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.035, 0.008, 0.006),
+        pos=(0.035, 0, 0),
+        mass=0.05,
+        rgba=(0.7, 0.2, 0.2, 1.0),
+    )
+    valve.add_geom(
+        name="valve_grip",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        fromto=(0.062, 0, -0.02, 0.062, 0, 0.02),
+        size=(0.007, 0, 0),
+        mass=0.02,
+        rgba=(0.2, 0.2, 0.22, 1.0),
+    )
+    valve.add_site(name="grip_site", pos=(0.062, 0, 0), size=(0.005, 0, 0))
+    return spec
+
+
+ROBOT_EE_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+VALVE_JOINT_CFG = SceneEntityCfg("valve", joint_names=("valve_turn",))
+VALVE_GRIP_CFG = SceneEntityCfg("valve", site_names=("grip_site",))
+
+FINGER_GRIP_SENSOR = ContactSensorCfg(
+    name="finger_grip_contact",
+    primary=ContactMatch(
+        mode="body",
+        pattern=r"openarm_right_ee_(inner|outer)_finger",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="valve_grip", entity="valve"),
+    fields=("found",),
+    reduce="none",
+    num_slots=1,
+)
+
+
+def openarm_valve_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm valve-turning environment config."""
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "valve_angle": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel,
+            params={"asset_cfg": VALVE_JOINT_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "ee_to_grip": ObservationTermCfg(
+            func=valve_mdp.ee_to_grip,
+            params={"robot_cfg": ROBOT_EE_CFG, "valve_cfg": VALVE_GRIP_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "grip_contact": ObservationTermCfg(
+            func=valve_mdp.grip_contact_obs,
+            params={"sensor_name": "finger_grip_contact"},
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+    actions: dict[str, ActionTermCfg] = {
+        "joint_pos": JointPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_.*",),
+            scale=BIMANUAL_ACTION_SCALE,
+            use_default_offset=True,
+        ),
+        "left_hold": HoldDefaultPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_.*",),
+            scale=1.0,
+            use_default_offset=True,
+        ),
+    }
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "reset_valve": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.3, 0.3),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("valve", joint_names=(".*",)),
+            },
+        ),
+        "record_valve_start": EventTermCfg(
+            func=valve_mdp.record_valve_start,
+            mode="reset",
+            params={"asset_cfg": VALVE_JOINT_CFG},
+        ),
+        # Domain randomization: each of the N parallel envs draws ONE fixed
+        # value at startup that persists its whole training life, matching
+        # mjlab's own reference convention (tasks/manipulation/
+        # lift_cube_env_cfg.py's fingertip_friction_* events). Ranges are
+        # proportional (operation="scale") and deliberately modest
+        # (roughly +-20-40%): the goal is to certify robustness, not make
+        # the task harder.
+        "dr_grip_friction": EventTermCfg(
+            mode="startup",
+            func=dr.geom_friction,
+            params={
+                "asset_cfg": SceneEntityCfg("valve", geom_names=("valve_grip",)),
+                "operation": "scale",
+                "distribution": "uniform",
+                "axes": [0],
+                "ranges": (0.6, 1.4),
+            },
+        ),
+        "dr_valve_joint_dynamics": EventTermCfg(
+            mode="startup",
+            func=dr.joint_friction,
+            params={
+                "asset_cfg": VALVE_JOINT_CFG,
+                "operation": "scale",
+                "distribution": "uniform",
+                "ranges": (0.5, 2.0),
+            },
+        ),
+        "dr_valve_joint_damping": EventTermCfg(
+            mode="startup",
+            func=dr.joint_damping,
+            params={
+                "asset_cfg": VALVE_JOINT_CFG,
+                "operation": "scale",
+                "distribution": "uniform",
+                "ranges": (0.5, 2.0),
+            },
+        ),
+        "dr_valve_mass": EventTermCfg(
+            mode="startup",
+            func=dr.pseudo_inertia,
+            params={
+                "asset_cfg": SceneEntityCfg("valve", body_names=("valve",)),
+                # alpha_range=(-0.1, 0.1): mass/inertia scale by e^(2*alpha),
+                # roughly 0.82x-1.22x, a physically-consistent density
+                # change (mass and inertia scaled together, per Rucker &
+                # Wensing 2022) rather than the bare body_mass shortcut.
+                "alpha_range": (-0.1, 0.1),
+            },
+        ),
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
+            },
+        ),
+    }
+    rewards = {
+        "reach_grip": RewardTermCfg(
+            func=valve_mdp.reach_grip_reward,
+            weight=1.0,
+            params={"std": 0.2, "robot_cfg": ROBOT_EE_CFG, "valve_cfg": VALVE_GRIP_CFG},
+        ),
+        "grip_contact": RewardTermCfg(
+            func=valve_mdp.grip_contact_reward,
+            weight=0.5,
+            params={"sensor_name": "finger_grip_contact"},
+        ),
+        "turn_rate": RewardTermCfg(
+            func=valve_mdp.turn_rate_reward,
+            weight=3.0,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": VALVE_JOINT_CFG},
+        ),
+        "turn_progress_shaping": RewardTermCfg(
+            func=valve_mdp.turn_progress_shaping_reward,
+            weight=2.0,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": VALVE_JOINT_CFG},
+        ),
+        "success": RewardTermCfg(
+            func=valve_mdp.turn_success_bonus, weight=500.0, params={}
+        ),
+        "reverse": RewardTermCfg(
+            func=valve_mdp.reverse_rate_penalty,
+            weight=-1.0,
+            params={"asset_cfg": VALVE_JOINT_CFG},
+        ),
+        "overspeed": RewardTermCfg(
+            func=valve_mdp.overspeed_penalty,
+            weight=-2.0,
+            params={"asset_cfg": VALVE_JOINT_CFG},
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg("robot", joint_names=("openarm_right_.*",)),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "turned_target": TerminationTermCfg(
+            func=valve_mdp.turned_target,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": VALVE_JOINT_CFG},
+        ),
+    }
+    valve_init = EntityCfg.InitialStateCfg(
+        pos=VALVE_POS,
+        joint_pos={"valve_turn": 0.0},
+        joint_vel={"valve_turn": 0.0},
+    )
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={
+                "robot": get_bimanual_robot_cfg(),
+                "valve": EntityCfg(spec_fn=get_valve_spec, init_state=valve_init),
+            },
+            num_envs=1,
+            env_spacing=2.5,
+            sensors=(FINGER_GRIP_SENSOR,),
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=1.6,
+            elevation=-20.0,
+            azimuth=200.0,
+        ),
+        sim=SimulationCfg(
+            nconmax=150,
+            njmax=1000,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        episode_length_s=8.0,
+    )
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
+++ b/src/openarm_mjlab/tasks/valve/valve_env_cfg.py
@@ -343,11 +343,14 @@ def openarm_valve_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         rewards=rewards,
         terminations=terminations,
         curriculum={},
+        # A fixed WORLD camera rather than an ASSET_BODY tracking one:
+        # MuJoCo tracking cameras follow the tracked body's subtree COM
+        # (here the whole right arm), so offscreen-rendered videos sway
+        # with every arm motion. mjlab's interactive viewer works around
+        # that, so the artifact only shows up in recorded video.
         viewer=ViewerConfig(
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
-            entity_name="robot",
-            body_name="openarm_right_base_link",
-            distance=1.6,
+            origin_type=ViewerConfig.OriginType.WORLD,
+            lookat=(0.30, 0.0, 0.52),
             elevation=-20.0,
             azimuth=200.0,
         ),

--- a/tests/test_valve_env.py
+++ b/tests/test_valve_env.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-Valve environment.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+# joint_pos/joint_vel report ALL 18 bimanual joints (both arms), regardless
+# of which arm this task actually actuates.
+OBS_DIM = 18 + 18 + 1 + 3 + 1 + 8  # joint_pos, joint_vel, valve_angle,
+# ee_to_grip, grip_contact, actions
+
+
+def test_task_is_registered():
+    assert "OpenArm-Valve" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Valve")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == 8
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_valve_start_angle_recorded_on_reset(env):
+    """`record_valve_start` must snapshot each env's angle at its own reset."""
+    from openarm_mjlab.tasks.valve.mdp import _start_angle, valve_angle
+    from openarm_mjlab.tasks.valve.valve_env_cfg import VALVE_JOINT_CFG
+
+    env.reset()
+    angle = valve_angle(env, VALVE_JOINT_CFG)
+    assert torch.allclose(_start_angle(env), angle)
+
+
+def test_left_arm_stays_at_default_under_zero_action(env):
+    """The parked left arm must hold its default pose, not drift to qpos 0."""
+    env.reset()
+    action = torch.zeros(2, env.action_manager.total_action_dim)
+    for _ in range(20):
+        env.step(action)
+    robot = env.scene["robot"]
+    left_j4 = robot.find_joints("openarm_left_joint4")[0][0]
+    # Home pose has joint4 at 1.5708 rad; qpos 0 would mean the hold failed.
+    assert torch.allclose(
+        robot.data.joint_pos[:, left_j4], torch.tensor(1.5708), atol=0.05
+    )


### PR DESCRIPTION
Right-arm valve-turning task: cage the vertical grip cylinder around the lever and turn it past a contact-honesty-gated target angle (77.4°). The success condition requires the turn to actually be produced under sustained grip contact, not just reached; a bare angle check can be satisfied by using the fixture as a prop rather than genuinely turning it.

This PR also adds the contact-gating helpers to `common_mdp.py` that the rest of the parts (door, drawer) reuse for the same check pattern.

**Results:** 100% clean success over 256 held-out episodes, turn achieved mean 82.1° / median 79.7° / min 76.1° (target: 77.4°), contact fraction mean 0.959 / min 0.901.

**Tests:** `tests/test_valve_env.py`, 5/5 passing — task registration, action/observation dimensions, finite-signal stepping, per-env start-angle snapshot on reset, and that the parked left arm holds its pose under zero action.