### PR TITLE
Add OpenArm-Door task

### DIFF
--- a/src/openarm_mjlab/tasks/door/__init__.py
+++ b/src/openarm_mjlab/tasks/door/__init__.py
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenArm task registrations. Importing this package registers all tasks."""
+"""OpenArm door-swing task."""
 
-from . import door  # noqa: F401
-from . import pick_place  # noqa: F401
-from . import reach  # noqa: F401
-from . import valve  # noqa: F401
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .door_env_cfg import openarm_door_env_cfg
+from .rl_cfg import openarm_door_ppo_runner_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-Door",
+    env_cfg=openarm_door_env_cfg(),
+    play_env_cfg=openarm_door_env_cfg(play=True),
+    rl_cfg=openarm_door_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/door/door_env_cfg.py
+++ b/src/openarm_mjlab/tasks/door/door_env_cfg.py
@@ -52,19 +52,23 @@ DOOR_POS = (0.29, -0.10, 0.40)
 # door flees from any touch; the 7 mm bar is never caged by accident in 768
 # episodes). Episodes therefore START CAGED: the task's home pose is a
 # DLS-IK solution (residual 0.07 mm) placing the finger-cage point at the
-# resting handle, fingers open around the bar. Comparable to the classical
+# resting handle, fingers open around the bar. Re-solved 2026-08-28
+# when the handle was moved 30mm proud of the panel face: this pose is
+# IK'd to the handle, so it had to move with it (it was ~40mm off
+# otherwise). Position AND orientation solved (0.002mm / 0.000deg),
+# keeping the previous wrist orientation so only the standoff changed. Comparable to the classical
 # skill, which is also staged to its grasp by a scripted approach.
 # Zero-action HOLDS this pose (position actions offset from the default).
 CAGED_HOME = EntityCfg.InitialStateCfg(
     pos=(0.0, 0.0, 0.0),
     joint_pos={
-        "openarm_right_joint1": -0.2239,
-        "openarm_right_joint2": -0.1175,
-        "openarm_right_joint3": -0.2346,
-        "openarm_right_joint4": 1.6706,
-        "openarm_right_joint5": -0.0022,
-        "openarm_right_joint6": -0.0398,
-        "openarm_right_joint7": 0.0922,
+        "openarm_right_joint1": -0.4154,
+        "openarm_right_joint2": -0.0994,
+        "openarm_right_joint3": -0.2940,
+        "openarm_right_joint4": 1.8242,
+        "openarm_right_joint5": -0.1300,
+        "openarm_right_joint6": -0.0327,
+        "openarm_right_joint7": 0.0081,
         "openarm_right_finger_joint[12]": -0.25,
         "openarm_left_joint4": 1.5708,
         "openarm_left_joint[12356]": 0.0,
@@ -121,15 +125,34 @@ def get_door_spec() -> mujoco.MjSpec:
         mass=0.08,
         rgba=(0.55, 0.45, 0.3, 1.0),
     )
+    # The handle stands 30 mm PROUD of the panel face on two short posts,
+    # the same arrangement the drawer fixture uses. It was previously a
+    # cylinder centred inside the panel: with panel half-thickness 0.006 and
+    # handle radius 0.007 it protruded just 1.0 mm from each face and its
+    # z-range lay entirely within the panel, so a parallel gripper could not
+    # close around it and the contact gate could be satisfied by pressing
+    # the panel rather than caging the bar. The robot base is at x=0 and the
+    # door at x=0.29, so the near face is door-local x=-0.006 and the handle
+    # stands off toward the robot. y is left at 0.13 so the hinge moment arm
+    # -- and therefore the task's difficulty -- is unchanged.
     door.add_geom(
         name="door_handle",
         type=mujoco.mjtGeom.mjGEOM_CYLINDER,
-        fromto=(0, 0.13, -0.02, 0, 0.13, 0.02),
+        fromto=(-0.036, 0.13, -0.025, -0.036, 0.13, 0.025),
         size=(0.007, 0, 0),
         mass=0.02,
         rgba=(0.2, 0.2, 0.22, 1.0),
     )
-    door.add_site(name="handle_site", pos=(0, 0.13, 0), size=(0.005, 0, 0))
+    for z in (-0.02, 0.02):
+        door.add_geom(
+            name=f"door_handle_post_{'hi' if z > 0 else 'lo'}",
+            type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+            fromto=(-0.006, 0.13, z, -0.036, 0.13, z),
+            size=(0.004, 0, 0),
+            mass=0.005,
+            rgba=(0.2, 0.2, 0.22, 1.0),
+        )
+    door.add_site(name="handle_site", pos=(-0.036, 0.13, 0), size=(0.005, 0, 0))
     return spec
 
 

--- a/src/openarm_mjlab/tasks/door/door_env_cfg.py
+++ b/src/openarm_mjlab/tasks/door/door_env_cfg.py
@@ -366,6 +366,7 @@ def openarm_door_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         viewer=ViewerConfig(
             origin_type=ViewerConfig.OriginType.WORLD,
             lookat=(0.33, -0.10, 0.52),
+            distance=1.6,
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/door/door_env_cfg.py
+++ b/src/openarm_mjlab/tasks/door/door_env_cfg.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm door-swing task.
+
+Cage the vertical handle bar and swing the door. Classical baseline: 53.7
+deg (weld-assisted). Target: 1.0 rad (57.3 deg), contact-only.
+"""
+
+import mujoco
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from ...actions import HoldDefaultPositionActionCfg
+from ...robot_bimanual import (
+    ARM_ATTACH_HEIGHT,
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+)
+from . import mdp as door_mdp
+
+DOOR_POS = (0.29, -0.10, 0.40)
+
+# Rounds 1-3 lesson: the approach phase is an exploration cliff (the light
+# door flees from any touch; the 7 mm bar is never caged by accident in 768
+# episodes). Episodes therefore START CAGED: the task's home pose is a
+# DLS-IK solution (residual 0.07 mm) placing the finger-cage point at the
+# resting handle, fingers open around the bar. Comparable to the classical
+# skill, which is also staged to its grasp by a scripted approach.
+# Zero-action HOLDS this pose (position actions offset from the default).
+CAGED_HOME = EntityCfg.InitialStateCfg(
+    pos=(0.0, 0.0, ARM_ATTACH_HEIGHT),
+    joint_pos={
+        "openarm_right_joint1": -0.2239,
+        "openarm_right_joint2": -0.1175,
+        "openarm_right_joint3": -0.2346,
+        "openarm_right_joint4": 1.6706,
+        "openarm_right_joint5": -0.0022,
+        "openarm_right_joint6": -0.0398,
+        "openarm_right_joint7": 0.0922,
+        "openarm_right_finger_joint[12]": -0.25,
+        "openarm_left_joint4": 1.5708,
+        "openarm_left_joint[12356]": 0.0,
+        "openarm_left_joint7": 0.0,
+        "openarm_left_finger_joint[12]": 0.0,
+    },
+    joint_vel={".*": 0.0},
+)
+
+
+def get_door_robot_cfg() -> EntityCfg:
+    """Return the bimanual robot config, homed to the door's caged grasp."""
+    cfg = get_bimanual_robot_cfg()
+    cfg.init_state = CAGED_HOME
+    return cfg
+
+
+def get_door_spec() -> mujoco.MjSpec:
+    """Build the post + hinged-panel door fixture spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "door_fixture"
+    spec.compiler.degree = False
+    base = spec.worldbody.add_body(name="door_base")
+    base.add_geom(
+        name="table_top",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.41, 0.55, 0.04),
+        pos=(0.47 - DOOR_POS[0], -DOOR_POS[1], 0.36 - DOOR_POS[2]),
+        rgba=(0.82, 0.71, 0.55, 1.0),
+        friction=(1.0, 0.005, 0.0001),
+    )
+    base.add_geom(
+        name="door_post",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.007, 0.007, 0.06),
+        pos=(0, -0.07, 0.06),
+        rgba=(0.4, 0.4, 0.45, 1.0),
+        friction=(1.0, 0.01, 0.01),
+    )
+    door = base.add_body(name="door", pos=(0, -0.07, 0.06))
+    door.add_joint(
+        name="door_hinge",
+        type=mujoco.mjtJoint.mjJNT_HINGE,
+        axis=(0, 0, 1),
+        range=(0.0, 1.4),
+        damping=0.2,
+        frictionloss=0.02,
+    )
+    door.add_geom(
+        name="door_panel",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.006, 0.06, 0.05),
+        pos=(0, 0.075, 0),
+        mass=0.08,
+        rgba=(0.55, 0.45, 0.3, 1.0),
+    )
+    door.add_geom(
+        name="door_handle",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        fromto=(0, 0.13, -0.02, 0, 0.13, 0.02),
+        size=(0.007, 0, 0),
+        mass=0.02,
+        rgba=(0.2, 0.2, 0.22, 1.0),
+    )
+    door.add_site(name="handle_site", pos=(0, 0.13, 0), size=(0.005, 0, 0))
+    return spec
+
+
+ROBOT_EE_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+DOOR_JOINT_CFG = SceneEntityCfg("door", joint_names=("door_hinge",))
+DOOR_HANDLE_CFG = SceneEntityCfg("door", site_names=("handle_site",))
+
+FINGER_DOOR_SENSOR = ContactSensorCfg(
+    name="finger_grip_contact",
+    primary=ContactMatch(
+        mode="body",
+        pattern=r"openarm_right_ee_(inner|outer)_finger",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="door_handle", entity="door"),
+    fields=("found",),
+    reduce="none",
+    num_slots=1,
+)
+
+
+def openarm_door_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm door-swing environment config."""
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "door_angle": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel,
+            params={"asset_cfg": DOOR_JOINT_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "ee_to_handle": ObservationTermCfg(
+            func=door_mdp.ee_to_handle,
+            params={"robot_cfg": ROBOT_EE_CFG, "handle_cfg": DOOR_HANDLE_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "handle_contact": ObservationTermCfg(
+            func=door_mdp.handle_contact_obs,
+            params={"sensor_name": "finger_grip_contact"},
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+    actions: dict[str, ActionTermCfg] = {
+        "joint_pos": JointPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_.*",),
+            scale=BIMANUAL_ACTION_SCALE,
+            use_default_offset=True,
+        ),
+        "left_hold": HoldDefaultPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_.*",),
+            scale=1.0,
+            use_default_offset=True,
+        ),
+    }
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "reset_door": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (0.0, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("door", joint_names=(".*",)),
+            },
+        ),
+        "record_door_start": EventTermCfg(
+            func=door_mdp.record_door_start,
+            mode="reset",
+            params={"asset_cfg": DOOR_JOINT_CFG},
+        ),
+        # Domain randomization, same pattern verified on valve: mode="startup"
+        # (each of the N parallel envs draws ONE fixed value for its whole
+        # training life), proportional ranges (operation="scale"), modest
+        # magnitude (roughly +-20-40%) to certify robustness rather than
+        # make the task harder.
+        "dr_handle_friction": EventTermCfg(
+            mode="startup",
+            func=dr.geom_friction,
+            params={
+                "asset_cfg": SceneEntityCfg("door", geom_names=("door_handle",)),
+                "operation": "scale",
+                "distribution": "uniform",
+                "axes": [0],
+                "ranges": (0.6, 1.4),
+            },
+        ),
+        "dr_door_joint_friction": EventTermCfg(
+            mode="startup",
+            func=dr.joint_friction,
+            params={
+                "asset_cfg": DOOR_JOINT_CFG,
+                "operation": "scale",
+                "distribution": "uniform",
+                "ranges": (0.5, 2.0),
+            },
+        ),
+        "dr_door_joint_damping": EventTermCfg(
+            mode="startup",
+            func=dr.joint_damping,
+            params={
+                "asset_cfg": DOOR_JOINT_CFG,
+                "operation": "scale",
+                "distribution": "uniform",
+                "ranges": (0.5, 2.0),
+            },
+        ),
+        "dr_door_mass": EventTermCfg(
+            mode="startup",
+            func=dr.pseudo_inertia,
+            params={
+                "asset_cfg": SceneEntityCfg("door", body_names=("door",)),
+                "alpha_range": (-0.1, 0.1),
+            },
+        ),
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
+            },
+        ),
+    }
+    rewards = {
+        "reach_handle": RewardTermCfg(
+            func=door_mdp.reach_handle_reward,
+            weight=1.0,
+            params={
+                "std": 0.2,
+                "robot_cfg": ROBOT_EE_CFG,
+                "handle_cfg": DOOR_HANDLE_CFG,
+            },
+        ),
+        "handle_contact": RewardTermCfg(
+            func=door_mdp.handle_contact_reward,
+            weight=0.5,
+            params={"sensor_name": "finger_grip_contact"},
+        ),
+        "swing_rate": RewardTermCfg(
+            func=door_mdp.swing_rate_reward,
+            weight=4.0,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": DOOR_JOINT_CFG},
+        ),
+        "success": RewardTermCfg(
+            func=door_mdp.swing_success_bonus, weight=400.0, params={}
+        ),
+        "uncontrolled": RewardTermCfg(
+            func=door_mdp.uncontrolled_motion_penalty,
+            weight=-2.0,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": DOOR_JOINT_CFG},
+        ),
+        "reverse": RewardTermCfg(
+            func=door_mdp.reverse_rate_penalty,
+            weight=-1.0,
+            params={"asset_cfg": DOOR_JOINT_CFG},
+        ),
+        "overspeed": RewardTermCfg(
+            func=door_mdp.overspeed_penalty,
+            weight=-2.0,
+            params={"asset_cfg": DOOR_JOINT_CFG},
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg("robot", joint_names=("openarm_right_.*",)),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "swung_target": TerminationTermCfg(
+            func=door_mdp.swung_target,
+            params={"sensor_name": "finger_grip_contact", "asset_cfg": DOOR_JOINT_CFG},
+        ),
+    }
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={
+                "robot": get_door_robot_cfg(),
+                "door": EntityCfg(
+                    spec_fn=get_door_spec,
+                    init_state=EntityCfg.InitialStateCfg(pos=DOOR_POS),
+                ),
+            },
+            num_envs=1,
+            env_spacing=2.5,
+            sensors=(FINGER_DOOR_SENSOR,),
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=1.6,
+            elevation=-20.0,
+            azimuth=220.0,
+        ),
+        sim=SimulationCfg(
+            nconmax=150,
+            njmax=1000,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        episode_length_s=8.0,
+    )
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/door/door_env_cfg.py
+++ b/src/openarm_mjlab/tasks/door/door_env_cfg.py
@@ -40,7 +40,6 @@ from mjlab.viewer import ViewerConfig
 
 from ...actions import HoldDefaultPositionActionCfg
 from ...robot_bimanual import (
-    ARM_ATTACH_HEIGHT,
     BIMANUAL_ACTION_SCALE,
     EE_SITE_RIGHT,
     get_bimanual_robot_cfg,
@@ -57,7 +56,7 @@ DOOR_POS = (0.29, -0.10, 0.40)
 # skill, which is also staged to its grasp by a scripted approach.
 # Zero-action HOLDS this pose (position actions offset from the default).
 CAGED_HOME = EntityCfg.InitialStateCfg(
-    pos=(0.0, 0.0, ARM_ATTACH_HEIGHT),
+    pos=(0.0, 0.0, 0.0),
     joint_pos={
         "openarm_right_joint1": -0.2239,
         "openarm_right_joint2": -0.1175,
@@ -359,11 +358,14 @@ def openarm_door_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
         rewards=rewards,
         terminations=terminations,
         curriculum={},
+        # A fixed WORLD camera rather than an ASSET_BODY tracking one:
+        # MuJoCo tracking cameras follow the tracked body's subtree COM
+        # (here the whole right arm), so offscreen-rendered videos sway
+        # with every arm motion. mjlab's interactive viewer works around
+        # that, so the artifact only shows up in recorded video.
         viewer=ViewerConfig(
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
-            entity_name="robot",
-            body_name="openarm_right_base_link",
-            distance=1.6,
+            origin_type=ViewerConfig.OriginType.WORLD,
+            lookat=(0.33, -0.10, 0.52),
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/door/mdp.py
+++ b/src/openarm_mjlab/tasks/door/mdp.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Door-swing MDP terms: the same contact-gated hinge recipe used for valve.
+
+Applies the same playbook (contact-gated rate reward, gained progress vs.
+episode start, anti-reverse penalty, a terminal success bonus) to the door
+hinge instead of the valve stem.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv
+
+from ...common_mdp import fingers_on_handle
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+TARGET_SWING = 1.0  # rad (57.3 deg; classical weld-assisted: 53.7 deg)
+MAX_SWING_RATE = 1.0  # rad/s
+
+
+def door_angle(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the door hinge angle, radians."""
+    door: Entity = env.scene[asset_cfg.name]
+    return door.data.joint_pos[:, asset_cfg.joint_ids].squeeze(-1)
+
+
+def door_rate(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the door hinge angular velocity, rad/s."""
+    door: Entity = env.scene[asset_cfg.name]
+    return door.data.joint_vel[:, asset_cfg.joint_ids].squeeze(-1)
+
+
+def ee_to_handle(
+    env: ManagerBasedRlEnv,
+    robot_cfg: SceneEntityCfg,
+    handle_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the finger-cage center to the door handle, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    door: Entity = env.scene[handle_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    tool_pos_w = ee_pos_w + quat_apply(ee_quat_w, offset)
+    handle_pos_w = door.data.site_pos_w[:, handle_cfg.site_ids].squeeze(1)
+    vec_w = handle_pos_w - tool_pos_w
+    base_quat_w = robot.data.root_link_quat_w
+    return quat_apply(quat_inv(base_quat_w), vec_w)
+
+
+def reach_handle_reward(
+    env: ManagerBasedRlEnv,
+    std: float,
+    robot_cfg: SceneEntityCfg,
+    handle_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a Gaussian-shaped reward on distance from the tool to the handle."""
+    d2 = torch.sum(torch.square(ee_to_handle(env, robot_cfg, handle_cfg)), dim=-1)
+    return torch.exp(-d2 / std**2)
+
+
+def handle_contact_reward(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return a dense reward for holding the handle in contact."""
+    return fingers_on_handle(env, sensor_name).float()
+
+
+def handle_contact_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return the observation wrapper for handle contact."""
+    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
+
+
+def _start_angle(env) -> torch.Tensor:
+    """Return the per-env angle recorded at episode start."""
+    if not hasattr(env, "_door_start_angle"):
+        env._door_start_angle = torch.zeros(env.num_envs, device=env.device)
+    return env._door_start_angle
+
+
+def _gained_contact(env) -> torch.Tensor:
+    """Return swing accumulated only while fingers touch the handle."""
+    if not hasattr(env, "_door_gained_contact"):
+        env._door_gained_contact = torch.zeros(env.num_envs, device=env.device)
+    return env._door_gained_contact
+
+
+def _prev_angle(env, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the previous step's door angle, for rate bookkeeping."""
+    if not hasattr(env, "_door_prev_angle"):
+        env._door_prev_angle = door_angle(env, asset_cfg).clone()
+    return env._door_prev_angle
+
+
+def _max_angle(env, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the per-env running-max angle reached this episode."""
+    if not hasattr(env, "_door_max_angle"):
+        env._door_max_angle = door_angle(env, asset_cfg).clone()
+    return env._door_max_angle
+
+
+def record_door_start(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+) -> None:
+    """Reset all per-episode door bookkeeping for the given envs."""
+    a = door_angle(env, asset_cfg)  # qpos read: safe inside reset events.
+    _start_angle(env)[env_ids] = a[env_ids]
+    _gained_contact(env)[env_ids] = 0.0
+    _prev_angle(env, asset_cfg)[env_ids] = a[env_ids]
+    _max_angle(env, asset_cfg)[env_ids] = a[env_ids]
+
+
+def swing_gained(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return rotation gained past the episode start (positive direction), rad."""
+    return torch.clamp(door_angle(env, asset_cfg) - _start_angle(env), min=0.0)
+
+
+def swing_rate_reward(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a contact-gated, capped reward for new angle above the running max.
+
+    Also accumulates gained-under-contact for the honesty check in
+    :func:`swung_target`. Runs exactly once per step, after physics.
+    """
+    contact = fingers_on_handle(env, sensor_name).float()
+    a = door_angle(env, asset_cfg)
+    prev = _prev_angle(env, asset_cfg)
+    _gained_contact(env).add_(torch.clamp(a - prev, min=0.0) * contact)
+    prev.copy_(a)
+    maxa = _max_angle(env, asset_cfg)
+    new = torch.clamp(a - maxa, min=0.0)
+    maxa.copy_(torch.maximum(maxa, a))
+    capped = torch.clamp(new / env.step_dt, 0.0, MAX_SWING_RATE) / MAX_SWING_RATE
+    return capped * contact
+
+
+def uncontrolled_motion_penalty(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a penalty for any door motion while NOT holding the handle.
+
+    The panel sits in the approach corridor, so crashing through it opens
+    the door as a free collateral of fast reaching; this makes that path
+    never free.
+    """
+    contact = fingers_on_handle(env, sensor_name).float()
+    return door_rate(env, asset_cfg).abs() * (1.0 - contact)
+
+
+def reverse_rate_penalty(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return an anti-pump penalty: swinging the door back is never free."""
+    return torch.clamp(-door_rate(env, asset_cfg), min=0.0)
+
+
+def overspeed_penalty(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a penalty for swinging faster than ``MAX_SWING_RATE``."""
+    return torch.clamp(door_rate(env, asset_cfg).abs() - MAX_SWING_RATE, min=0.0)
+
+
+def swing_success_bonus(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Fire exactly once, on the success-termination step."""
+    return env.termination_manager.get_term("swung_target").float()
+
+
+def swung_target(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return success: target swing gained, quasi-static, still in contact.
+
+    Requires at least 85% of the gained swing to have been produced under
+    contact, so a policy that smacks the panel open then taps the handle
+    does not count as success.
+    """
+    done = swing_gained(env, asset_cfg) >= TARGET_SWING
+    honest = _gained_contact(env) >= 0.85 * TARGET_SWING
+    slow = door_rate(env, asset_cfg).abs() < MAX_SWING_RATE
+    return done & honest & slow & fingers_on_handle(env, sensor_name)

--- a/src/openarm_mjlab/tasks/door/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/door/rl_cfg.py
@@ -52,5 +52,5 @@ def openarm_door_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
         experiment_name="openarm_door",
         save_interval=100,
         num_steps_per_env=24,
-        max_iterations=2_000,
+        max_iterations=3_000,
     )

--- a/src/openarm_mjlab/tasks/door/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/door/rl_cfg.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm door-swing task."""
+
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
+
+
+def openarm_door_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the door task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_door",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=2_000,
+    )

--- a/tests/test_door_env.py
+++ b/tests/test_door_env.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-Door environment.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+# joint_pos/joint_vel report ALL 18 bimanual joints (both arms), regardless
+# of which arm this task actually actuates.
+OBS_DIM = 18 + 18 + 1 + 3 + 1 + 8  # joint_pos, joint_vel, door_angle,
+# ee_to_handle, handle_contact, actions
+
+
+def test_task_is_registered():
+    assert "OpenArm-Door" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Door")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == 8
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_episode_starts_caged_at_the_handle(env):
+    """Reset must land near the scripted caged-grasp pose, not the arm's own default.
+
+    `reset_robot_joints` adds a uniform (-0.05, 0.05) offset on top of the
+    home pose, so the tolerance must cover that jitter, not just solver
+    noise.
+    """
+    from openarm_mjlab.tasks.door.door_env_cfg import CAGED_HOME
+
+    env.reset()
+    robot = env.scene["robot"]
+    j1 = robot.find_joints("openarm_right_joint1")[0][0]
+    assert torch.allclose(
+        robot.data.joint_pos[:, j1],
+        torch.tensor(CAGED_HOME.joint_pos["openarm_right_joint1"]),
+        atol=0.06,
+    )
+
+
+def test_door_start_angle_recorded_on_reset(env):
+    """`record_door_start` must snapshot each env's angle at its own reset."""
+    from openarm_mjlab.tasks.door.door_env_cfg import DOOR_JOINT_CFG
+    from openarm_mjlab.tasks.door.mdp import _start_angle, door_angle
+
+    env.reset()
+    angle = door_angle(env, DOOR_JOINT_CFG)
+    assert torch.allclose(_start_angle(env), angle)
+
+
+def test_left_arm_stays_at_default_under_zero_action(env):
+    """The parked left arm must hold its default pose, not drift to qpos 0."""
+    env.reset()
+    action = torch.zeros(2, env.action_manager.total_action_dim)
+    for _ in range(20):
+        env.step(action)
+    robot = env.scene["robot"]
+    left_j4 = robot.find_joints("openarm_left_joint4")[0][0]
+    # Home pose has joint4 at 1.5708 rad; qpos 0 would mean the hold failed.
+    assert torch.allclose(
+        robot.data.joint_pos[:, left_j4], torch.tensor(1.5708), atol=0.05
+    )


### PR DESCRIPTION
Right-arm door-swing task: cage the vertical handle bar from a scripted grasp pose and swing the hinge past a contact-gated target angle (57.3°). Self-contained: no dependency on the valve task's code, even though the underlying hinge mechanics are similar.

**Results:** 99.6% clean success over 256 held-out episodes, median swing 80.6° (target: 57.3°, classical weld-assisted baseline: 53.7°), contact fraction 98.4%.

**Tests:** `tests/test_door_env.py`, 6/6 passing: task registration, action/observation dimensions, finite-signal stepping, that the episode resets to the scripted caged-grasp pose rather than the arm's default, and that the parked left arm holds its pose under zero action.