### PR TITLE
Add OpenArm-Puck task (privileged and vision variants)

### DIFF
--- a/src/openarm_mjlab/tasks/__init__.py
+++ b/src/openarm_mjlab/tasks/__init__.py
@@ -15,5 +15,6 @@
 """OpenArm task registrations. Importing this package registers all tasks."""
 
 from . import pick_place  # noqa: F401
+from . import puck  # noqa: F401
 from . import reach  # noqa: F401
 from . import valve  # noqa: F401

--- a/src/openarm_mjlab/tasks/puck/__init__.py
+++ b/src/openarm_mjlab/tasks/puck/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenArm move-puck task, privileged and vision variants."""
+
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .puck_env_cfg import openarm_puck_env_cfg
+from .rl_cfg import openarm_puck_ppo_runner_cfg, openarm_puck_vision_ppo_runner_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-Puck",
+    env_cfg=openarm_puck_env_cfg(),
+    play_env_cfg=openarm_puck_env_cfg(play=True),
+    rl_cfg=openarm_puck_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)
+
+# Same task/rewards/terminations/events -- only the actor's observations
+# change (privileged puck-position terms swapped for a fixed overhead
+# depth camera). Separate task_id so the privileged checkpoint is never
+# touched.
+register_mjlab_task(
+    task_id="OpenArm-Puck-Vision",
+    env_cfg=openarm_puck_env_cfg(vision=True),
+    play_env_cfg=openarm_puck_env_cfg(play=True, vision=True),
+    rl_cfg=openarm_puck_vision_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/puck/mdp.py
+++ b/src/openarm_mjlab/tasks/puck/mdp.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Move-puck (pushing) MDP terms.
+
+Pushing needs no grasp, so the anti-cheat surface is smaller than the
+drawer/valve tasks: the one exploit to close is FLICKING (smack the puck
+and let it coast to the goal). The approach-rate reward is contact-gated
+and capped (coasting earns nothing), success requires the puck SETTLED at
+the goal, and puck overspeed is penalized.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv
+
+from ...common_mdp import fingers_on_handle
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+# Goal disc, local to the env origin.
+GOAL_LOCAL = (0.33, -0.30, 0.422)
+SUCCESS_DIST = 0.025  # m, planar.
+SETTLED_SPEED = 0.05  # m/s
+MAX_PUSH_SPEED = 0.25  # m/s, puck speed cap for the rate reward.
+
+
+def _goal_w(env) -> torch.Tensor:
+    # mjlab batches each env as its OWN world: physics coordinates are
+    # raw; env_origins is only a viewer layout grid. Do NOT add origins.
+    goal = torch.tensor(GOAL_LOCAL, device=env.device)
+    return goal.expand(env.num_envs, 3)
+
+
+def puck_pos_w(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the puck's world position."""
+    puck: Entity = env.scene[asset_cfg.name]
+    return puck.data.root_link_pos_w
+
+
+def puck_speed(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the puck's planar speed."""
+    puck: Entity = env.scene[asset_cfg.name]
+    return torch.linalg.norm(puck.data.root_link_vel_w[:, :2], dim=-1)
+
+
+def puck_goal_dist(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the planar distance from the puck to the goal center."""
+    d = puck_pos_w(env, asset_cfg)[:, :2] - _goal_w(env)[:, :2]
+    return torch.linalg.norm(d, dim=-1)
+
+
+def puck_to_goal_obs(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+    robot_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the puck to the goal, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    vec_w = _goal_w(env) - puck_pos_w(env, asset_cfg)
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def tool_to_puck_obs(
+    env: ManagerBasedRlEnv,
+    robot_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the finger-cage center to the puck, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    tool_w = ee_pos_w + quat_apply(ee_quat_w, offset)
+    vec_w = puck_pos_w(env, asset_cfg) - tool_w
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def reach_puck_reward(
+    env: ManagerBasedRlEnv,
+    std: float,
+    robot_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a Gaussian-kernel reward on tool-to-puck distance."""
+    d2 = torch.sum(torch.square(tool_to_puck_obs(env, robot_cfg, asset_cfg)), dim=-1)
+    return torch.exp(-d2 / std**2)
+
+
+def push_contact_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return the observation wrapper for puck contact."""
+    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
+
+
+def push_rate_reward(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a contact-gated, capped rate of approach to the goal (0..1).
+
+    Coasting after a flick earns nothing (contact gate); speed above the
+    cap earns no more than the cap. New-progress-only against the
+    episode's best distance so push-pull cycling cannot farm income.
+    """
+    dist = puck_goal_dist(env, asset_cfg)
+    if not hasattr(env, "_puck_min_dist"):
+        env._puck_min_dist = dist.clone()
+    new = torch.clamp(env._puck_min_dist - dist, min=0.0)
+    env._puck_min_dist.copy_(torch.minimum(env._puck_min_dist, dist))
+    capped = torch.clamp(new / env.step_dt, 0.0, MAX_PUSH_SPEED) / MAX_PUSH_SPEED
+    return capped * fingers_on_handle(env, sensor_name).float()
+
+
+def at_goal_reward(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return a reward for settling at the goal: close AND slow.
+
+    A 1.2x band, not the exact success band: outside it the hold pays
+    nothing, so parking just inside the success band without truly
+    settling has no income.
+    """
+    close = puck_goal_dist(env, asset_cfg) < 1.2 * SUCCESS_DIST
+    slow = puck_speed(env, asset_cfg) < SETTLED_SPEED
+    return (close & slow).float()
+
+
+def goal_fine_reward(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return a dense centering gradient in the 0-10cm band.
+
+    The rate reward saturates near the goal disc, so nothing else pulls
+    the puck the last few centimeters without this term.
+    """
+    d = puck_goal_dist(env, asset_cfg)
+    return torch.exp(-((d / 0.05) ** 2))
+
+
+def puck_overspeed_penalty(
+    env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Return a penalty for puck speed beyond ``MAX_PUSH_SPEED``."""
+    return torch.clamp(puck_speed(env, asset_cfg) - MAX_PUSH_SPEED, min=0.0)
+
+
+def push_success_bonus(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Fire exactly once, on the ``puck_at_goal`` termination step."""
+    return env.termination_manager.get_term("puck_at_goal").float()
+
+
+def puck_at_goal(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return success: the puck settled inside the goal disc."""
+    close = puck_goal_dist(env, asset_cfg) < SUCCESS_DIST
+    slow = puck_speed(env, asset_cfg) < SETTLED_SPEED
+    return close & slow
+
+
+def puck_fell(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return early termination: the puck was knocked off the table (top z=0.40)."""
+    return puck_pos_w(env, asset_cfg)[:, 2] < 0.30
+
+
+def puck_fell_penalty(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Return a penalty on the ``puck_fell`` termination step.
+
+    The direct negative counterpart to :func:`push_success_bonus`: without
+    it, a fall is only punished implicitly (by forfeiting future dense
+    income), which is too weak a deterrent once a policy drifts toward a
+    faster, more aggressive push -- ending in a fall should be punished as
+    directly as ending in success is rewarded.
+    """
+    return env.termination_manager.get_term("puck_fell").float()
+
+
+def reset_puck_uniform(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    xy_range: float = 0.03,
+) -> None:
+    """Reset the puck to its default pose plus xy jitter.
+
+    Free-body resets must start from the default state (which already
+    contains the env origin for attached free bodies) and add jitter on
+    top, rather than adding origins a second time.
+    """
+    puck: Entity = env.scene[asset_cfg.name]
+    default = puck.data.default_root_state
+    assert default is not None
+    state = default[env_ids].clone()
+    n = len(env_ids)
+    state[:, 0] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 1] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 7:] = 0.0
+    puck.write_root_state_to_sim(state, env_ids=env_ids)
+    # Seed the rate buffer from the WRITTEN positions: derived kinematics
+    # are stale inside reset events.
+    goal = torch.tensor(GOAL_LOCAL, device=env.device)
+    d = torch.linalg.norm(state[:, :2] - goal[:2], dim=-1)
+    if not hasattr(env, "_puck_min_dist"):
+        env._puck_min_dist = puck_goal_dist(env, asset_cfg).clone()
+    env._puck_min_dist[env_ids] = d

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -1,0 +1,358 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm move-puck task.
+
+A 70x70x44mm puck is pushed into a goal disc and left there. Pushing
+needs no grasp: fully feasible contact-only.
+"""
+
+import mujoco
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sensor import CameraSensorCfg, ContactMatch, ContactSensorCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from ...actions import HoldDefaultPositionActionCfg
+from ...robot_bimanual import (
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+)
+from . import mdp as puck_mdp
+
+PUCK_START = (0.20, -0.14, 0.422)
+
+
+def get_table_spec() -> mujoco.MjSpec:
+    """Build the static table slab + goal disc marker spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "puck_table"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="table")
+    body.add_geom(
+        name="table_top",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.41, 0.55, 0.04),
+        pos=(0.47, 0.0, 0.36),
+        rgba=(0.82, 0.71, 0.55, 1.0),
+        friction=(1.0, 0.005, 0.0001),
+    )
+    body.add_site(
+        name="goal_site",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        size=(0.05, 0.001, 0),
+        pos=(puck_mdp.GOAL_LOCAL[0], puck_mdp.GOAL_LOCAL[1], 0.401),
+        rgba=(0.2, 0.8, 0.3, 0.4),
+    )
+    return spec
+
+
+def get_puck_spec() -> mujoco.MjSpec:
+    """Build the free-body puck fixture spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "puck"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="puck")
+    body.add_freejoint(name="puck_free")
+    body.add_geom(
+        name="puck_geom",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.035, 0.035, 0.022),
+        mass=0.2,
+        friction=(0.4, 0.01, 0.01),
+        rgba=(0.85, 0.4, 0.1, 1.0),
+    )
+    return spec
+
+
+ROBOT_EE_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+PUCK_CFG = SceneEntityCfg("puck")
+
+FINGER_PUCK_SENSOR = ContactSensorCfg(
+    name="finger_puck_contact",
+    primary=ContactMatch(
+        mode="subtree",
+        pattern="openarm_right_ee_base_link",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="puck_geom", entity="puck"),
+    fields=("found",),
+    reduce="none",
+    num_slots=1,
+)
+
+# World-fixed overhead depth camera. A MuJoCo camera looks down its own
+# -Z by convention, so the identity quaternion here means straight down.
+PUCK_TABLECAM_POS = (0.26, -0.18, 1.15)
+PUCK_TABLECAM_QUAT = (1.0, 0.0, 0.0, 0.0)
+PUCK_TABLECAM_FOVY = 60.0
+
+
+def openarm_puck_env_cfg(
+    play: bool = False, vision: bool = False
+) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm move-puck environment config.
+
+    With ``vision=True``, the actor loses the privileged puck-position
+    observation terms and instead relies on a fixed overhead depth
+    camera; the critic (discarded at deployment) keeps full privileged
+    state and also gets the camera, the same asymmetric actor-critic
+    pattern mjlab's own vision reference task uses.
+    """
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "tool_to_puck": ObservationTermCfg(
+            func=puck_mdp.tool_to_puck_obs,
+            params={"robot_cfg": ROBOT_EE_CFG, "asset_cfg": PUCK_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "puck_to_goal": ObservationTermCfg(
+            func=puck_mdp.puck_to_goal_obs,
+            params={"asset_cfg": PUCK_CFG, "robot_cfg": ROBOT_EE_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "push_contact": ObservationTermCfg(
+            func=puck_mdp.push_contact_obs,
+            params={"sensor_name": "finger_puck_contact"},
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+    actions: dict[str, ActionTermCfg] = {
+        "joint_pos": JointPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_.*",),
+            scale=BIMANUAL_ACTION_SCALE,
+            use_default_offset=True,
+        ),
+        "left_hold": HoldDefaultPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_.*",),
+            scale=1.0,
+            use_default_offset=True,
+        ),
+    }
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "reset_puck": EventTermCfg(
+            func=puck_mdp.reset_puck_uniform,
+            mode="reset",
+            params={"asset_cfg": PUCK_CFG, "xy_range": 0.03},
+        ),
+        # Domain randomization, same verified pattern as the other tasks.
+        # Puck is a free body (no joint dynamics axis, like reach) --
+        # friction, mass, and arm gains only.
+        "dr_puck_friction": EventTermCfg(
+            mode="startup",
+            func=dr.geom_friction,
+            params={
+                "asset_cfg": SceneEntityCfg("puck", geom_names=("puck_geom",)),
+                "operation": "scale",
+                "distribution": "uniform",
+                "axes": [0],
+                "ranges": (0.6, 1.4),
+            },
+        ),
+        "dr_puck_mass": EventTermCfg(
+            mode="startup",
+            func=dr.pseudo_inertia,
+            params={
+                "asset_cfg": SceneEntityCfg("puck", body_names=("puck",)),
+                "alpha_range": (-0.1, 0.1),
+            },
+        ),
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
+            },
+        ),
+    }
+    rewards = {
+        "reach_puck": RewardTermCfg(
+            func=puck_mdp.reach_puck_reward,
+            weight=1.0,
+            params={"std": 0.2, "robot_cfg": ROBOT_EE_CFG, "asset_cfg": PUCK_CFG},
+        ),
+        "push_rate": RewardTermCfg(
+            func=puck_mdp.push_rate_reward,
+            weight=3.0,
+            params={"sensor_name": "finger_puck_contact", "asset_cfg": PUCK_CFG},
+        ),
+        "goal_fine": RewardTermCfg(
+            func=puck_mdp.goal_fine_reward, weight=2.0, params={"asset_cfg": PUCK_CFG}
+        ),
+        "at_goal": RewardTermCfg(
+            func=puck_mdp.at_goal_reward, weight=2.0, params={"asset_cfg": PUCK_CFG}
+        ),
+        "success": RewardTermCfg(
+            func=puck_mdp.push_success_bonus, weight=800.0, params={}
+        ),
+        "puck_overspeed": RewardTermCfg(
+            func=puck_mdp.puck_overspeed_penalty,
+            weight=-2.0,
+            params={"asset_cfg": PUCK_CFG},
+        ),
+        # Direct negative counterpart to "success" (half its magnitude):
+        # without this, a fall was only punished implicitly by losing
+        # future dense income, too weak a deterrent once training drifts
+        # toward a faster, more aggressive push.
+        "puck_fell": RewardTermCfg(
+            func=puck_mdp.puck_fell_penalty, weight=-400.0, params={}
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg("robot", joint_names=("openarm_right_.*",)),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "puck_at_goal": TerminationTermCfg(
+            func=puck_mdp.puck_at_goal, params={"asset_cfg": PUCK_CFG}
+        ),
+        "puck_fell": TerminationTermCfg(
+            func=puck_mdp.puck_fell, params={"asset_cfg": PUCK_CFG}
+        ),
+    }
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={
+                "robot": get_bimanual_robot_cfg(),
+                "table": EntityCfg(spec_fn=get_table_spec),
+                "puck": EntityCfg(
+                    spec_fn=get_puck_spec,
+                    init_state=EntityCfg.InitialStateCfg(pos=PUCK_START),
+                ),
+            },
+            num_envs=1,
+            env_spacing=2.5,
+            sensors=(FINGER_PUCK_SENSOR,),
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=1.6,
+            elevation=-20.0,
+            azimuth=220.0,
+        ),
+        sim=SimulationCfg(
+            nconmax=150,
+            njmax=1000,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        episode_length_s=8.0,
+    )
+    if vision:
+        # Depth-only (matches mjlab's own vision reference task's
+        # simplest variant): avoids RGB/lighting domain-randomization
+        # complexity for a first vision attempt. The camera group is
+        # separate from "actor"/"critic" so rl_cfg's obs_groups controls
+        # which policy sees it.
+        cam_cfg = CameraSensorCfg(
+            name="tablecam",
+            pos=PUCK_TABLECAM_POS,
+            quat=PUCK_TABLECAM_QUAT,
+            fovy=PUCK_TABLECAM_FOVY,
+            width=64,
+            height=64,
+            data_types=("depth",),
+            use_shadows=False,
+            use_textures=True,
+        )
+        cfg.scene.sensors = (cfg.scene.sensors or ()) + (cam_cfg,)
+        cfg.observations["camera"] = ObservationGroupCfg(
+            terms={
+                "tablecam_depth": ObservationTermCfg(
+                    func=manipulation_mdp.camera_depth,
+                    params={"sensor_name": "tablecam", "cutoff_distance": 1.0},
+                ),
+            },
+            enable_corruption=False,
+            concatenate_terms=True,
+        )
+        # The puck's goal is a fixed constant (not resampled per
+        # episode), so no separate goal-conditioning term is needed --
+        # the network can learn it directly.
+        actor_obs = cfg.observations["actor"]
+        actor_obs.terms.pop("tool_to_puck")
+        actor_obs.terms.pop("puck_to_goal")
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -87,6 +87,20 @@ def get_puck_spec() -> mujoco.MjSpec:
         mass=0.2,
         friction=(0.4, 0.01, 0.01),
         rgba=(0.85, 0.4, 0.1, 1.0),
+        # Without a priority this friction never applied anywhere, so the
+        # puck was declared slippery and never was. MuJoCo takes the
+        # higher-priority geom's contact parameters and mixes only when
+        # priorities are equal, and that mix is an elementwise MAX. The
+        # right-arm finger geoms are priority=1, so they governed the push
+        # contact at mu=1.0; the table is priority=0 like the puck was, so
+        # that pair mixed to max(0.4, 1.0) = 1.0 as well. dr_puck_friction
+        # was randomizing a number MuJoCo read on neither pair. Outranking
+        # both makes the declared 0.4 govern (measured: 0.4 at the finger
+        # and 0.4 at the table). condim=4 and the fingers' own solref keep
+        # the finger contact model as it was, so only the friction changes.
+        priority=2,
+        condim=4,
+        solref=(0.005, 1.0),
     )
     return spec
 

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -304,6 +304,7 @@ def openarm_puck_env_cfg(
         viewer=ViewerConfig(
             origin_type=ViewerConfig.OriginType.WORLD,
             lookat=(0.28, -0.22, 0.50),
+            distance=1.6,
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -296,11 +296,14 @@ def openarm_puck_env_cfg(
         rewards=rewards,
         terminations=terminations,
         curriculum={},
+        # A fixed WORLD camera rather than an ASSET_BODY tracking one:
+        # MuJoCo tracking cameras follow the tracked body's subtree COM
+        # (here the whole right arm), so offscreen-rendered videos sway
+        # with every arm motion. mjlab's interactive viewer works around
+        # that, so the artifact only shows up in recorded video.
         viewer=ViewerConfig(
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
-            entity_name="robot",
-            body_name="openarm_right_base_link",
-            distance=1.6,
+            origin_type=ViewerConfig.OriginType.WORLD,
+            lookat=(0.28, -0.22, 0.50),
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/puck/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/rl_cfg.py
@@ -52,7 +52,7 @@ def openarm_puck_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
         experiment_name="openarm_puck",
         save_interval=100,
         num_steps_per_env=24,
-        max_iterations=2_000,
+        max_iterations=3_000,
     )
 
 

--- a/src/openarm_mjlab/tasks/puck/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/rl_cfg.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm move-puck task, privileged and vision variants."""
+
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
+
+
+def openarm_puck_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the privileged-state puck task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_puck",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=2_000,
+    )
+
+
+# Same small CNN + spatial-softmax architecture mjlab's own vision
+# reference task uses: proven, not reinvented.
+_VISION_CNN_CFG = {
+    "output_channels": [16, 32],
+    "kernel_size": [5, 3],
+    "stride": [2, 2],
+    "padding": "zeros",
+    "activation": "elu",
+    "max_pool": False,
+    "global_pool": "none",
+    "spatial_softmax": True,
+    "spatial_softmax_temperature": 1.0,
+}
+_VISION_MODEL_CLS = "mjlab.rl.spatial_softmax:SpatialSoftmaxCNNModel"
+
+
+def openarm_puck_vision_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the depth-camera-only puck task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(256, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            cnn_cfg=_VISION_CNN_CFG,
+            class_name=_VISION_MODEL_CLS,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(256, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            cnn_cfg=_VISION_CNN_CFG,
+            class_name=_VISION_MODEL_CLS,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_puck_vision",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=3_000,
+        obs_groups={
+            "actor": ("actor", "camera"),
+            "critic": ("critic", "camera"),
+        },
+    )

--- a/tests/test_puck_env.py
+++ b/tests/test_puck_env.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-Puck and OpenArm-Puck-Vision environments.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+# joint_pos/joint_vel report ALL 18 bimanual joints (both arms), regardless
+# of which arm this task actually actuates.
+OBS_DIM = 18 + 18 + 3 + 3 + 1 + 8  # joint_pos, joint_vel, tool_to_puck,
+# puck_to_goal, push_contact, actions
+VISION_ACTOR_OBS_DIM = OBS_DIM - 3 - 3  # privileged puck-position terms dropped.
+
+
+def test_tasks_are_registered():
+    assert "OpenArm-Puck" in list_tasks()
+    assert "OpenArm-Puck-Vision" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Puck")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+@pytest.fixture(scope="module")
+def vision_env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Puck-Vision")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == 8
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_reset_puck_spawns_within_xy_range(env):
+    """`reset_puck_uniform` must spawn every env within its declared jitter."""
+    from openarm_mjlab.tasks.puck.puck_env_cfg import PUCK_CFG, PUCK_START
+    from openarm_mjlab.tasks.puck.mdp import puck_pos_w
+
+    env.reset()
+    pos = puck_pos_w(env, PUCK_CFG)
+    start = torch.tensor(PUCK_START[:2])
+    assert (pos[:, :2] - start).abs().max() <= 0.03 + 1e-6
+
+
+def test_vision_actor_drops_privileged_puck_state(vision_env):
+    """The vision actor must lose the privileged terms while the critic keeps them."""
+    obs, _ = vision_env.reset()
+    assert obs["actor"].shape == (2, VISION_ACTOR_OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+    assert obs["camera"].shape == (2, 1, 64, 64)
+
+
+def test_vision_env_steps_with_finite_signals(vision_env):
+    vision_env.reset()
+    for _ in range(5):
+        action = torch.zeros(2, vision_env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = vision_env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(obs["camera"]).all()
+        assert torch.isfinite(rew).all()
+
+
+def test_left_arm_stays_at_default_under_zero_action(env):
+    """The parked left arm must hold its default pose, not drift to qpos 0."""
+    env.reset()
+    action = torch.zeros(2, env.action_manager.total_action_dim)
+    for _ in range(20):
+        env.step(action)
+    robot = env.scene["robot"]
+    left_j4 = robot.find_joints("openarm_left_joint4")[0][0]
+    # Home pose has joint4 at 1.5708 rad; qpos 0 would mean the hold failed.
+    assert torch.allclose(
+        robot.data.joint_pos[:, left_j4], torch.tensor(1.5708), atol=0.05
+    )


### PR DESCRIPTION
Right-arm contact-only pushing task: push a free-body puck into a fixed goal and settle it there. Registers two task_ids sharing the same rewards/terminations/events: OpenArm-Puck (privileged puck-position observations) and OpenArm-Puck-Vision (a fixed overhead depth camera replaces the privileged terms for the actor, asymmetric actor-critic).

**Results:** OpenArm-Puck: 99.6% clean success over 256 held-out episodes, mean settle distance 13.9mm (classical baseline: ~10mm). OpenArm-Puck-Vision: 72.7% clean success, 1.2% falls, closest approach 27.8mm — depth-camera-only at inference; included as a converged result on its own terms.

**Tests:** `tests/test_puck_env.py`, 7/7 passing: task registration for both variants, action/observation dimensions, finite-signal stepping, randomized puck spawn range, that the vision actor's observations genuinely drop privileged puck state, and that the parked left arm holds its pose under zero action.