### PR TITLE
Add OpenArm-BimanualLift task

### DIFF
--- a/src/openarm_mjlab/tasks/bimanual_lift/__init__.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/__init__.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenArm task registrations. Importing this package registers all tasks."""
+"""OpenArm bimanual bar-lifting task."""
 
-from . import bimanual_lift  # noqa: F401
-from . import door  # noqa: F401
-from . import pick_place  # noqa: F401
-from . import reach  # noqa: F401
-from . import valve  # noqa: F401
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .bimanual_lift_env_cfg import openarm_bimanual_lift_env_cfg
+from .rl_cfg import openarm_bimanual_lift_ppo_runner_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-BimanualLift",
+    env_cfg=openarm_bimanual_lift_env_cfg(),
+    play_env_cfg=openarm_bimanual_lift_env_cfg(play=True),
+    rl_cfg=openarm_bimanual_lift_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
@@ -361,6 +361,14 @@ def get_bar_spec() -> mujoco.MjSpec:
     end_half = (0.025, 0.025, 0.03)
     end_mass = 0.05
     end_friction = (2.5, 0.1, 0.01)
+    # Both arms' finger collision geoms are priority=1, so a
+    # default-priority bar end is outranked and the fingers' parameters
+    # govern every grasp contact: the 2.5 grip friction authored here was
+    # never read (measured: effective mu 1.0 on both ends). priority=2
+    # puts these geoms above the fingers so their own friction applies.
+    # condim=4 is required as well -- at the default condim=3 MuJoCo
+    # ignores the torsional component, which is what resists the bar
+    # twisting out of a two-point grasp.
     body.add_geom(
         name="bar_end_right_geom",
         type=mujoco.mjtGeom.mjGEOM_BOX,
@@ -368,8 +376,19 @@ def get_bar_spec() -> mujoco.MjSpec:
         pos=bl_mdp.RIGHT_END_OFFSET,
         mass=end_mass,
         friction=end_friction,
+        priority=2,
+        condim=4,
+        solref=(0.005, 1.0),
         rgba=(0.9, 0.2, 0.2, 1.0),
     )
+    # Both arms' finger collision geoms are priority=1, so a
+    # default-priority bar end is outranked and the fingers' parameters
+    # govern every grasp contact: the 2.5 grip friction authored here was
+    # never read (measured: effective mu 1.0 on both ends). priority=2
+    # puts these geoms above the fingers so their own friction applies.
+    # condim=4 is required as well -- at the default condim=3 MuJoCo
+    # ignores the torsional component, which is what resists the bar
+    # twisting out of a two-point grasp.
     body.add_geom(
         name="bar_end_left_geom",
         type=mujoco.mjtGeom.mjGEOM_BOX,
@@ -377,6 +396,9 @@ def get_bar_spec() -> mujoco.MjSpec:
         pos=bl_mdp.LEFT_END_OFFSET,
         mass=end_mass,
         friction=end_friction,
+        priority=2,
+        condim=4,
+        solref=(0.005, 1.0),
         rgba=(0.2, 0.3, 0.9, 1.0),
     )
     # Rod spans between the two end blocks' inner faces (offset ∓ half

--- a/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
@@ -1,0 +1,806 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm bimanual lift task.
+
+Bimanual lift task: BOTH arms grip their own end of a 370 mm bar and
+
+raise it together.
+
+Every prior task in this suite (reach/valve/puck/move_puck/door/drawer/
+lift) only ever actively controls the RIGHT arm; the left arm is parked
+via HoldDefaultPositionActionCfg. Genuine bimanual coordination is the one
+untapped capability of this platform (the classical sibling project has a
+full bimanual controller, openarm_control/bimanual.py; the RL side never
+touched it). This task requires both arms because the bar is deliberately
+too long for either ~30 mm gripper cage to lift alone without the far,
+ungripped end simply tipping/dragging: unless both ends are genuinely
+gripped and raised in sync, a single-arm attempt rotates the bar about its
+one grip point rather than lifting it.
+
+SCENE GEOMETRY -- avoiding a real, documented collision mode:
+
+The two arms mount only 62 mm apart at the base (openarm_v20_bimanual.xml:
+174/259, `openarm_left_base_link pos="0 0.031 0"` / `openarm_right_base_
+link pos="0 -0.031 0"`), and the classical sibling project's README
+(Limitations & scope) documents a real failure mode already hit and
+designed around there: "Two close-mounted 7-DOF arms collide when *both*
+reach over one centred object (their upper arms cross)" -- which is why
+its own bottle-unscrew and cloth-fold tasks are single-arm, while its
+working simultaneous-bimanual demos (ParallelSort, BimanualStack) keep
+both arms' targets well off the centerline.
+
+This task's two grip points are placed at that SAME proven-safe
+separation, not merely "some wide number": bar end offset
+END_Y_OFFSET=0.16 m (see mdp.py) is copied directly from
+openarm_control/bimanual.py's ParallelSort, whose right_jobs pick at
+(0.18, -0.16) SIMULTANEOUSLY with left_jobs at (0.18, +0.16) -- an
+already-working, non-colliding, both-arms-at-once configuration in the
+same robot model. It is independently corroborated from the mjlab side
+too: reach/mdp.py's own validated right-arm workspace box has y in
+[-0.35, -0.05], and -0.16 sits comfortably mid-box, nowhere near either
+the centerline (y=0, the risky zone) or the box edge. Both arms' resting
+default pose (HOME_KEYFRAME, elbow bent up at 1.5708 rad, everything else
+at 0 -- unchanged here, see get_bimanual_lift_robot_cfg below) also never
+requires either arm's IK solution to sweep across the other's side, since
+each end sits within that arm's OWN existing validated workspace box, not
+centered between the two.
+
+Total bar length (outer face to outer face) works out to END_Y_OFFSET*2 +
+2*block_half_width = 0.32 + 0.05 = 0.37 m -- a bit past the 250-350mm
+originally sketched, a deliberate trade: given the documented collision
+risk, erring toward MORE separation than the minimum proven-safe value
+(0.16) rather than trimming back toward it purely to hit a round number.
+
+OPEN UNCERTAINTY (see final report): this reasoning transfers the
+CLASSICAL project's proven y-separation number into the MJLAB scene by
+axis-and-magnitude analogy (same robot mesh, same base spacing, same
+general x-depth-and-y-separation geometry), not by re-running IK in this
+scene -- the two projects use different absolute coordinate origins (the
+classical pick_xy values don't share mjlab's x convention, only the
+y-axis separation logic was carried over). It is corroborated by mjlab's
+OWN reach-task workspace box, which is a stronger same-scene signal than
+the cross-project number alone. Still, no IK or physics check was run in
+this scene (code-only task, no GPU) -- a human should watch specifically
+for self-collision or upper-arm crossing during early exploration at the
+GPU smoke test, per the instructions this task was built under.
+"""
+
+import mujoco
+
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sensor import ContactMatch, ContactSensorCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from mjlab.actuator import BuiltinPositionActuatorCfg, IdealPdActuatorCfg
+from mjlab.entity import EntityArticulationInfoCfg
+from mjlab.envs.mdp.actions import JointEffortActionCfg
+
+from ...robot_bimanual import (
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_LEFT,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+    get_bimanual_spec,
+)
+from . import mdp as bl_mdp
+
+
+# 2026-08-23 fix: the
+# module docstring below in get_bimanual_lift_robot_cfg used to explain,
+# honestly, why init_state stayed the plain HOME_KEYFRAME -- no verified
+# two-arm IK pose existed yet. an earlier attempt later solved and verified
+# one (bl_mdp.HELD_HIGH_RIGHT_Q/LEFT_Q, error 0.046mm), but only ever
+# used it inside the reset_bar_held_high EVENT, never as the entity's
+# actual default pose -- so JointPositionAction's use_default_offset
+# (snapshotted ONCE at build time from entity.data.default_joint_pos,
+# see mjlab/envs/mdp/actions/actions.py) stayed anchored to
+# HOME_KEYFRAME regardless of what any reset event wrote into the sim. A
+# direct zero-action probe confirmed this: a held-high reset gets yanked
+# back toward HOME_KEYFRAME and the bar drops from 100mm to 30mm within
+# 9 steps (~180ms) -- the same "zero action yanks the arm home" bug
+# lift's own review #3 found and fixed via LIFT_HOME. This mirrors that
+# exact fix: BIMANUAL_LIFT_HOME uses the already-solved, already-
+# verified held-high joint values as the DEFAULT pose for both arms (and
+# starts both fingers near their squeeze targets, matching LIFT_HOME's
+# own "-0.25, already near-closed" convention), so zero action holds the
+# arm right where a genuine grip-and-lift needs it, exactly like lift's
+# LIFT_HOME == HELD_HIGH_POSE trick.
+BIMANUAL_LIFT_HOME = EntityCfg.InitialStateCfg(
+    pos=(0.0, 0.0, 0.0),
+    joint_pos={
+        "openarm_right_joint1": bl_mdp.HELD_HIGH_RIGHT_Q[0],
+        "openarm_right_joint2": bl_mdp.HELD_HIGH_RIGHT_Q[1],
+        "openarm_right_joint3": bl_mdp.HELD_HIGH_RIGHT_Q[2],
+        "openarm_right_joint4": bl_mdp.HELD_HIGH_RIGHT_Q[3],
+        "openarm_right_joint5": bl_mdp.HELD_HIGH_RIGHT_Q[4],
+        "openarm_right_joint6": bl_mdp.HELD_HIGH_RIGHT_Q[5],
+        "openarm_right_joint7": bl_mdp.HELD_HIGH_RIGHT_Q[6],
+        "openarm_right_finger_joint1": bl_mdp.RIGHT_FINGER_SQUEEZE,
+        "openarm_left_joint1": bl_mdp.HELD_HIGH_LEFT_Q[0],
+        "openarm_left_joint2": bl_mdp.HELD_HIGH_LEFT_Q[1],
+        "openarm_left_joint3": bl_mdp.HELD_HIGH_LEFT_Q[2],
+        "openarm_left_joint4": bl_mdp.HELD_HIGH_LEFT_Q[3],
+        "openarm_left_joint5": bl_mdp.HELD_HIGH_LEFT_Q[4],
+        "openarm_left_joint6": bl_mdp.HELD_HIGH_LEFT_Q[5],
+        "openarm_left_joint7": bl_mdp.HELD_HIGH_LEFT_Q[6],
+        "openarm_left_finger_joint1": bl_mdp.LEFT_FINGER_SQUEEZE,
+    },
+    joint_vel={".*": 0.0},
+)
+
+
+def get_bimanual_lift_spec() -> mujoco.MjSpec:
+    """Build the robot spec with both fingers effort-controlled.
+
+    Both fingers are raw-effort-controlled in this task (see the
+
+    actuator cfg below), so BOTH need lift's get_lift_spec() joint-limit
+    fix, not just the right one. the "Fourth attempt"
+    (an earlier attempt) found MuJoCo's default solref_limit/solimp_limit lets a
+    SUSTAINED raw-effort command drive a finger joint roughly double past
+    its own hard stop -- a compliance level that's fine for every
+    position-controlled joint (which self-limits via ctrlrange long before
+    pressing hard against its stop) but not for direct torque control. That
+    only ever mattered for the one raw-effort joint in the codebase before
+    this task; now there are two, so both get the identical, probe-verified
+    stiffening an earlier attempt landed on. Scoped to this task's spec only, same as
+    lift's get_lift_spec.
+    """
+    spec = get_bimanual_spec()
+    for j in spec.joints:
+        if j.name in ("openarm_right_finger_joint1", "openarm_left_finger_joint1"):
+            j.solref_limit = [0.004, 1.0]
+            j.solimp_limit = [0.98, 0.999, 0.0002, 0.5, 2.0]
+    return spec
+
+
+def get_bimanual_lift_robot_cfg():
+    """Entity config for the bimanual arms in this task."""
+    cfg = get_bimanual_robot_cfg()
+    # 2026-08-23: init_state now BIMANUAL_LIFT_HOME (see its docstring
+    # above for the full root-cause diagnosis and fix rationale) -- was
+    # the plain HOME_KEYFRAME through an earlier attempt, which is what
+    # caused the held-high curriculum's own yank-back bug. Both arms'
+    # "reach" is correspondingly easier now (hovering near the grip point,
+    # not the far neutral pose), same trade lift's own LIFT_HOME already
+    # made and shipped successfully -- reach_right/reach_left still have a
+    # real, non-trivial gap to close (the bar sits below/at table height,
+    # the default pose hovers HELD_HIGH_RAISE above that), so this is not
+    # a "reach already solved for free" shortcut, just the same default-
+    # offset anchor lift itself uses.
+    cfg.init_state = BIMANUAL_LIFT_HOME
+    cfg.spec_fn = get_bimanual_lift_spec
+    actuators = (
+        BuiltinPositionActuatorCfg(
+            target_names_expr=("openarm_(left|right)_joint[12]",),
+            stiffness=230.0,
+            damping=2.7,
+            effort_limit=40.0,
+        ),
+        BuiltinPositionActuatorCfg(
+            target_names_expr=("openarm_(left|right)_joint[34]",),
+            stiffness=190.0,
+            damping=2.2,
+            effort_limit=27.0,
+        ),
+        BuiltinPositionActuatorCfg(
+            target_names_expr=("openarm_(left|right)_joint[567]",),
+            stiffness=30.0,
+            damping=1.5,
+            effort_limit=7.0,
+        ),
+        # Right finger: effort_limit=7 matches ITS OWN XML actuatorfrcrange
+        # ("-7 7", openarm_v20_bimanual.xml:323) -- the an earlier attempt fix. A
+        # borrowed 30 Nm figure from a different actuator was harmless for
+        # position control and directly became the max commandable torque
+        # once switched to raw effort.
+        IdealPdActuatorCfg(
+            target_names_expr=("openarm_right_finger_joint1",),
+            stiffness=0.0,
+            damping=2.0,
+            effort_limit=7.0,
+        ),
+        # Left finger's OWN XML actuatorfrcrange is "-10 10"
+        # (openarm_v20_bimanual.xml:238) -- NOT symmetric with the right
+        # finger's 7 Nm (a quirk of the upstream model, confirmed by reading
+        # the XML directly, not assumed). Reading each joint's own designed
+        # capacity rather than assuming left/right symmetry is exactly the
+        # an earlier attempt lesson ("30 Nm was never this joint's real designed
+        # capacity, just a borrowed number") applied to a joint that has
+        # never been under effort control before this task.
+        IdealPdActuatorCfg(
+            target_names_expr=("openarm_left_finger_joint1",),
+            stiffness=0.0,
+            damping=2.0,
+            effort_limit=10.0,
+        ),
+    )
+    cfg.articulation = EntityArticulationInfoCfg(
+        actuators=actuators, soft_joint_pos_limit_factor=0.9
+    )
+    return cfg
+
+
+# Arm-only scale (fingers excluded, matching lift's LIFT_ARM_SCALE
+# derivation exactly): both fingers are effort-controlled now, so the
+# position action for either arm must not carry a finger scale key.
+BIMANUAL_ARM_SCALE = {
+    k: v for k, v in BIMANUAL_ACTION_SCALE.items() if "finger" not in k
+}
+
+# Right squeeze scale=2.0 is an earlier attempt/12's own probe-verified value (a
+# 1-sigma exploration action lands at ~2 Nm against the right finger's 7
+# Nm cap -- the "settles at the true joint limit" regime, not the
+# saturating one). The left finger was ASSUMED to have a 10 Nm cap and
+# scaled proportionally (2.0 * (10.0/7.0) ~= 2.857) -- this was flagged
+# in this same comment as an unverified extrapolation needing a direct
+# saturation-probe recheck, which was never actually done until the
+# 2026-08-25 bimanual-lift asymmetry investigation ran it: a direct
+# compiled-model check (`left_finger1_ctrl`/`right_finger1_ctrl`
+# actuator forcerange) shows BOTH fingers are genuinely capped at 7 Nm,
+# not 10 -- there is no 10 Nm actuator anywhere in the asset. The old
+# scale therefore gave the left squeeze action ~43% more effective
+# torque per unit of policy output than the right (2.857/7=0.408 of its
+# real cap vs. right's proven 2.0/7=0.286), a real, mechanistic
+# candidate for the left/right grip asymmetry seen in both trained seeds
+# (left grips reliably, right barely does): larger effective torque per
+# unit of exploration noise makes the left actuator far more likely to
+# reach full-squeeze during early random exploration. Corrected to match
+# right's proven value now that both arms are confirmed to share the
+# same real 7 Nm cap.
+RIGHT_SQUEEZE_SCALE = 2.0
+LEFT_SQUEEZE_SCALE = 2.0
+
+ROBOT_EE_RIGHT_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+ROBOT_EE_LEFT_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_LEFT,))
+BAR_CFG = SceneEntityCfg("bar")
+
+FINGER_BAR_SENSOR_RIGHT = ContactSensorCfg(
+    name="finger_bar_contact_right",
+    primary=ContactMatch(
+        mode="body",
+        pattern=r"openarm_right_ee_(inner|outer)_finger",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="bar_end_right_geom", entity="bar"),
+    # "force" added 2026-08-26 for the grasp-quality reward: the
+    # binary "found" alone cannot distinguish a feather touch from a
+    # secure clamp, which is the diagnosed root cause of the
+    # never-lifts plateau (see the project notes).
+    fields=("found", "force", "dist", "pos"),
+    reduce="none",
+    num_slots=1,
+)
+FINGER_BAR_SENSOR_LEFT = ContactSensorCfg(
+    name="finger_bar_contact_left",
+    primary=ContactMatch(
+        mode="body",
+        pattern=r"openarm_left_ee_(inner|outer)_finger",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="bar_end_left_geom", entity="bar"),
+    # "force" added 2026-08-26 for the grasp-quality reward: the
+    # binary "found" alone cannot distinguish a feather touch from a
+    # secure clamp, which is the diagnosed root cause of the
+    # never-lifts plateau (see the project notes).
+    fields=("found", "force", "dist", "pos"),
+    reduce="none",
+    num_slots=1,
+)
+
+
+def get_bimanual_table_spec() -> mujoco.MjSpec:
+    """Build the static table slab the bar rests on."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "bimanual_lift_table"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="table")
+    body.add_geom(
+        name="table_top",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.41, 0.55, 0.04),
+        pos=(0.47, 0.0, 0.36),
+        rgba=(0.82, 0.71, 0.55, 1.0),
+        friction=(1.0, 0.005, 0.0001),
+    )
+    return spec
+
+
+def get_bar_spec() -> mujoco.MjSpec:
+    """Build the two-ended bar the arms lift together.
+
+    Bimanual bar: two lift-block-identical grip ends (mass/friction
+
+    copied verbatim from lift's proven get_block_spec() -- the exact
+    physical regime that finally made a friction-only pinch work, per
+    the project notes) joined by a thin connecting rod, all one rigid
+    body/freejoint. Grip-point placement (RIGHT_END_OFFSET/LEFT_END_OFFSET)
+    and the reasoning behind END_Y_OFFSET live in mdp.py / this module's
+    docstring.
+
+    Being one rigid body is deliberate: if only one end is genuinely
+    gripped, the ungripped end doesn't stay magically fixed -- it simply
+    goes wherever the bar's actual rigid-body physics takes it (drags,
+    tips, or stays resting on the table while the gripped end rises),
+    which is exactly what produces the height-mismatch signal the
+    together_* rewards in mdp.py gate on. No separate interlock or
+    scripted logic is needed to enforce "together" -- it falls out of
+    rigid-body dynamics plus the reward shaping.
+    """
+    spec = mujoco.MjSpec()
+    spec.modelname = "bimanual_bar"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="bar")
+    body.add_freejoint(name="bar_free")
+    end_half = (0.025, 0.025, 0.03)
+    end_mass = 0.05
+    end_friction = (2.5, 0.1, 0.01)
+    body.add_geom(
+        name="bar_end_right_geom",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=end_half,
+        pos=bl_mdp.RIGHT_END_OFFSET,
+        mass=end_mass,
+        friction=end_friction,
+        rgba=(0.9, 0.2, 0.2, 1.0),
+    )
+    body.add_geom(
+        name="bar_end_left_geom",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=end_half,
+        pos=bl_mdp.LEFT_END_OFFSET,
+        mass=end_mass,
+        friction=end_friction,
+        rgba=(0.2, 0.3, 0.9, 1.0),
+    )
+    # Rod spans between the two end blocks' inner faces (offset ∓ half
+    # width in y), connecting them into one visible bar. Not a grip
+    # surface (the sensors above target the end geoms specifically), so
+    # its own friction is unused by the reward logic; given a modest
+    # generic value only for contact stability if the arm brushes it.
+    rod_half_y = bl_mdp.END_Y_OFFSET - end_half[1]
+    body.add_geom(
+        name="bar_rod_geom",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        fromto=(0.0, -rod_half_y, 0.0, 0.0, rod_half_y, 0.0),
+        size=(0.008, 0, 0),
+        mass=0.02,
+        friction=(0.5, 0.005, 0.0001),
+        rgba=(0.5, 0.5, 0.55, 1.0),
+    )
+    # 2026-08-20 NaN-bug fix, root-caused via mjlab's own NaN-guard dump
+    # (a real crash from the first full 1024-env training run, not a
+    # hypothetical): auto-computed inertia from these geoms alone gives
+    # principal moments [2.733e-3, 2.723e-3, 5.15e-5] kg*m^2 -- the third
+    # axis (the bar's own long/roll axis, through both grip points) is
+    # ~53x LOWER than the other two, because both end blocks' mass sits
+    # far from the bar's center (large tip-over resistance) but close to
+    # the roll axis itself (~zero roll resistance contributed by the
+    # separation). Confirmed via mj_setState replay of the crash dump:
+    # the freejoint's ANGULAR velocity (not position, not any robot
+    # joint) grew smoothly by orders of magnitude over ~14 steps
+    # (2.8e2 -> 3.0e16) right up to the NaN -- the signature of a stiff
+    # contact torque hitting a near-degenerate rotational inertia, not a
+    # single-step singularity. Explicit fullinertia override pads ONLY
+    # that roll axis (5.15e-5 -> 1.0e-3, ratio 53:1 -> ~2.7:1), same
+    # total mass, same collision/visual geometry, same grip surfaces --
+    # this changes nothing about what the task requires, it only removes
+    # a numerical-modeling artifact of representing a real object with
+    # two thin-ish box+cylinder primitives. Standard MuJoCo practice for
+    # thin/light rotating bodies (see MuJoCo's own inertia-fitting
+    # guidance), not a task simplification.
+    body.mass = end_mass * 2 + 0.02
+    body.fullinertia = [2.733e-3, 1.0e-3, 2.723e-3, 0.0, 0.0, 0.0]
+    body.explicitinertial = True
+    return spec
+
+
+def openarm_bimanual_lift_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm bimanual lift environment config."""
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "tool_to_right_end": ObservationTermCfg(
+            func=bl_mdp.tool_to_end_obs,
+            params={
+                "robot_cfg": ROBOT_EE_RIGHT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.RIGHT_END_OFFSET,
+            },
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "tool_to_left_end": ObservationTermCfg(
+            func=bl_mdp.tool_to_end_obs,
+            params={
+                "robot_cfg": ROBOT_EE_LEFT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.LEFT_END_OFFSET,
+            },
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "pinch_right": ObservationTermCfg(
+            func=bl_mdp.pinch_obs, params={"sensor_name": "finger_bar_contact_right"}
+        ),
+        "pinch_left": ObservationTermCfg(
+            func=bl_mdp.pinch_obs, params={"sensor_name": "finger_bar_contact_left"}
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+
+    # BOTH arms actively controlled -- no HoldDefaultPositionActionCfg in
+    # this task. Four independent action terms (two 7-dim arm position
+    # terms, two 1-dim finger effort terms) so the policy can genuinely
+    # coordinate rather than being forced to mirror one arm's command onto
+    # the other.
+    right_arm = JointPositionActionCfg(
+        entity_name="robot",
+        actuator_names=("openarm_right_joint[1-7]",),
+        scale=BIMANUAL_ARM_SCALE,
+        use_default_offset=True,
+    )
+    left_arm = JointPositionActionCfg(
+        entity_name="robot",
+        actuator_names=("openarm_left_joint[1-7]",),
+        scale=BIMANUAL_ARM_SCALE,
+        use_default_offset=True,
+    )
+    actions: dict[str, ActionTermCfg] = {
+        "right_arm": right_arm,
+        "left_arm": left_arm,
+        "right_squeeze": JointEffortActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_finger_joint1",),
+            scale=RIGHT_SQUEEZE_SCALE,
+        ),
+        "left_squeeze": JointEffortActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_finger_joint1",),
+            scale=LEFT_SQUEEZE_SCALE,
+        ),
+    }
+
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "reset_bar": EventTermCfg(
+            func=bl_mdp.reset_bar_uniform,
+            mode="reset",
+            params={"asset_cfg": BAR_CFG, "xy_range": 0.03},
+        ),
+        # Must run after reset_bar (overrides the subset it picks) --
+        # An earlier attempt showed that neither individual nor together lift
+        # rewards ever fired even once in 3000 iterations from a cold
+        # start. Rewritten 2026-08-23 to drop the arm-joint teleport/anneal
+        # entirely now that BIMANUAL_LIFT_HOME (above) IS the held-high
+        # pose -- see mdp.py's HELD_HIGH_PROBABILITY docstring for the
+        # yank-back bug this fixes and reset_bar_held_high's own docstring
+        # for why only the bar needs moving now, exactly mirroring lift's
+        # own reset_held_high. probability left at its default (0.15,
+        # lift's own proven ratio) rather than passed explicitly here.
+        "reset_bar_held_high": EventTermCfg(
+            func=bl_mdp.reset_bar_held_high,
+            mode="reset",
+            params={
+                "asset_cfg": BAR_CFG,
+                "robot_joints_cfg": SceneEntityCfg("robot"),
+            },
+        ),
+    }
+
+    rewards = {
+        # Split coarse/fine at UNCHANGED total weight (0.7+0.3 = the old 1.0),
+        # so camping income and the success-bonus margin are untouched. The
+        # coarse std of 0.2m is saturated (0.992) at the 18mm positioning error
+        # that the measured grasp actually has, so on its own it supplies no
+        # gradient for the last centimetre -- which is why the grasp forms high
+        # on the block and peels off under load. The fine term restores that
+        # gradient exactly where it was missing. Same coarse/fine pattern the
+        # drawer task already uses.
+        "reach_right": RewardTermCfg(
+            func=bl_mdp.reach_bar_end_reward,
+            weight=0.7,
+            params={
+                "std": 0.2,
+                "robot_cfg": ROBOT_EE_RIGHT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.RIGHT_END_OFFSET,
+            },
+        ),
+        "reach_fine_right": RewardTermCfg(
+            func=bl_mdp.reach_bar_end_reward,
+            weight=0.3,
+            params={
+                "std": 0.02,
+                "robot_cfg": ROBOT_EE_RIGHT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.RIGHT_END_OFFSET,
+            },
+        ),
+        # Split coarse/fine at UNCHANGED total weight (0.7+0.3 = the old 1.0),
+        # so camping income and the success-bonus margin are untouched. The
+        # coarse std of 0.2m is saturated (0.992) at the 18mm positioning error
+        # that the measured grasp actually has, so on its own it supplies no
+        # gradient for the last centimetre -- which is why the grasp forms high
+        # on the block and peels off under load. The fine term restores that
+        # gradient exactly where it was missing. Same coarse/fine pattern the
+        # drawer task already uses.
+        "reach_left": RewardTermCfg(
+            func=bl_mdp.reach_bar_end_reward,
+            weight=0.7,
+            params={
+                "std": 0.2,
+                "robot_cfg": ROBOT_EE_LEFT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.LEFT_END_OFFSET,
+            },
+        ),
+        "reach_fine_left": RewardTermCfg(
+            func=bl_mdp.reach_bar_end_reward,
+            weight=0.3,
+            params={
+                "std": 0.02,
+                "robot_cfg": ROBOT_EE_LEFT_CFG,
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.LEFT_END_OFFSET,
+            },
+        ),
+        "pinch_right": RewardTermCfg(
+            func=bl_mdp.pinch_reward,
+            weight=0.5,
+            params={"sensor_name": "finger_bar_contact_right"},
+        ),
+        "pinch_left": RewardTermCfg(
+            func=bl_mdp.pinch_reward,
+            weight=0.5,
+            params={"sensor_name": "finger_bar_contact_left"},
+        ),
+        "partial_pinch_right": RewardTermCfg(
+            func=bl_mdp.partial_pinch_reward,
+            weight=0.3,
+            params={"sensor_name": "finger_bar_contact_right"},
+        ),
+        "partial_pinch_left": RewardTermCfg(
+            func=bl_mdp.partial_pinch_reward,
+            weight=0.3,
+            params={"sensor_name": "finger_bar_contact_left"},
+        ),
+        "pinch_streak_together": RewardTermCfg(
+            func=bl_mdp.together_pinch_streak_reward,
+            weight=1.5,
+            params={
+                "sensor_right": "finger_bar_contact_right",
+                "sensor_left": "finger_bar_contact_left",
+            },
+        ),
+        "lift_rate_together": RewardTermCfg(
+            func=bl_mdp.together_lift_rate_reward,
+            weight=3.0,
+            params={
+                "sensor_right": "finger_bar_contact_right",
+                "sensor_left": "finger_bar_contact_left",
+                "asset_cfg": BAR_CFG,
+            },
+        ),
+        # An earlier attempt showed that lift_rate_together alone stayed at exact
+        # zero for 2500+ iterations after reach/grip/level all saturated --
+        # min()-gating means both arms' exploration noise must coincide
+        # before any lift reward appears from a cold start. These two
+        # bootstrapping companions (see individual_lift_rate_reward's
+        # docstring) let each arm discover "lifting my own end is
+        # possible" independently. Weighted well below lift_rate_together
+        # (0.5+0.5 vs 3.0) so together_* stays the dominant channel --
+        # this can only help escape the plateau, not substitute for it.
+        "individual_lift_right": RewardTermCfg(
+            func=bl_mdp.individual_lift_rate_reward,
+            weight=0.5,
+            params={
+                "sensor_name": "finger_bar_contact_right",
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.RIGHT_END_OFFSET,
+                "side": "right",
+            },
+        ),
+        "individual_lift_left": RewardTermCfg(
+            func=bl_mdp.individual_lift_rate_reward,
+            weight=0.5,
+            params={
+                "sensor_name": "finger_bar_contact_left",
+                "asset_cfg": BAR_CFG,
+                "local_offset": bl_mdp.LEFT_END_OFFSET,
+                "side": "left",
+            },
+        ),
+        "held_high_together": RewardTermCfg(
+            func=bl_mdp.together_held_high_reward,
+            weight=2.0,
+            params={
+                "sensor_right": "finger_bar_contact_right",
+                "sensor_left": "finger_bar_contact_left",
+                "asset_cfg": BAR_CFG,
+            },
+        ),
+        "level": RewardTermCfg(
+            func=bl_mdp.level_reward,
+            weight=1.0,
+            params={
+                "sensor_right": "finger_bar_contact_right",
+                "sensor_left": "finger_bar_contact_left",
+                "asset_cfg": BAR_CFG,
+                "std": 0.03,
+            },
+        ),
+        # An earlier attempt showed that the ORIGINAL comment here used a gamma-
+        # discounted-infinite-horizon estimate ("810") to justify weight
+        # 1000 -- that framework was superseded by an earlier attempt/an earlier attempt's actual
+        # postmortem this same session, which established the real
+        # comparison is bonus_reward (weight*dt, one-shot) vs. the FULL
+        # EPISODE-LENGTH camping income (steady-state weight-sum *
+        # episode_length_s), since a policy that never triggers success
+        # collects dense income for the WHOLE episode, not a
+        # discounted-forever approximation. Re-run with the corrected
+        # framework: steady-state per-step income = reach_right+reach_left
+        # (2.0) + pinch_right+pinch_left(1.0) + partial_pinch_right+
+        # partial_pinch_left(0.6) + pinch_streak_together capped(1.5) +
+        # held_high_together(2.0) + level(1.0) = 8.1/step -> full-episode
+        # (8.0s) camping ceiling = 64.8. The old weight=1000 (20.0 real
+        # reward) was NEVER sufficient -- 20.0 << 64.8, the exact same
+        # "camping pays more than succeeding" bug an earlier attempt had, just never
+        # observed here because the policy never got tall enough to
+        # exploit it (it plateaued at reach+grip+level, height ~0, before
+        # ever reaching the point where this would matter). Corrected to
+        # weight=3660 (73.2 real reward, 1.13x the 3240 minimum) --
+        # matching an earlier attempt's own validated ratio (which worked) rather than
+        # an earlier attempt's 1.42x (which destabilized training), since this is now
+        # the only empirical data point available for what ratio is safe.
+        "success": RewardTermCfg(
+            func=bl_mdp.together_success_bonus, weight=3660.0, params={}
+        ),
+        "descent": RewardTermCfg(
+            func=bl_mdp.bar_descent_penalty,
+            weight=-2.0,
+            params={"asset_cfg": BAR_CFG},
+        ),
+        "overshoot": RewardTermCfg(
+            func=bl_mdp.together_overshoot_penalty,
+            weight=-10.0,
+            params={"asset_cfg": BAR_CFG},
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_.*",)
+                ),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "lifted_together": TerminationTermCfg(
+            func=bl_mdp.lifted_together,
+            params={
+                "sensor_right": "finger_bar_contact_right",
+                "sensor_left": "finger_bar_contact_left",
+                "asset_cfg": BAR_CFG,
+            },
+        ),
+        "bar_fell": TerminationTermCfg(
+            func=bl_mdp.bar_fell,
+            params={"asset_cfg": BAR_CFG},
+        ),
+    }
+
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={
+                "robot": get_bimanual_lift_robot_cfg(),
+                # Reused unmodified from lift (same table, same world placement)
+                # -- its footprint (half-extents x=0.41, y=0.55) already spans
+                # well past this bar's y=±0.16-ish grip points, so no new table
+                # geometry is needed.
+                "table": EntityCfg(spec_fn=get_bimanual_table_spec),
+                "bar": EntityCfg(
+                    spec_fn=get_bar_spec,
+                    init_state=EntityCfg.InitialStateCfg(pos=bl_mdp.BAR_START),
+                ),
+            },
+            num_envs=1,
+            env_spacing=2.5,
+            sensors=(FINGER_BAR_SENSOR_RIGHT, FINGER_BAR_SENSOR_LEFT),
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=2.0,
+            elevation=-20.0,
+            azimuth=220.0,
+        ),
+        sim=SimulationCfg(
+            # Bumped from lift's 150/1000: this scene has twice the manipulated
+            # contact pairs (two grippers x their own bar end, plus the shared
+            # table) that lift's single-block scene has. A conservative,
+            # untested increase -- purely a static buffer size, so higher is
+            # safe; flagged for the human to watch for MuJoCo buffer-overflow
+            # warnings at the GPU smoke test and raise further if needed.
+            nconmax=200,
+            njmax=1400,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        # Matches lift's proven episode budget exactly -- same actuator/
+        # timestep regime, no evidence yet to retune for the bimanual case.
+        episode_length_s=8.0,
+    )
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/bimanual_lift_env_cfg.py
@@ -81,6 +81,7 @@ import mujoco
 
 from mjlab.entity import EntityCfg
 from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
 from mjlab.envs.mdp.actions import JointPositionActionCfg
 from mjlab.managers.action_manager import ActionTermCfg
 from mjlab.managers.event_manager import EventTermCfg
@@ -546,6 +547,50 @@ def openarm_bimanual_lift_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
             params={
                 "asset_cfg": BAR_CFG,
                 "robot_joints_cfg": SceneEntityCfg("robot"),
+            },
+        ),
+        # Domain randomization, same pattern and magnitudes as lift's.
+        # mode="startup" so each parallel env draws one fixed value for its
+        # whole training life, matching mjlab's own reference convention.
+        #
+        # Randomizing the bar's friction only became meaningful once the end
+        # geoms were given contact priority: at default priority the fingers
+        # outranked them and MuJoCo never read the bar's friction at all, so
+        # this term would have randomized a value with no effect, which is
+        # exactly the dead-randomization defect the other tasks had.
+        "dr_bar_friction": EventTermCfg(
+            mode="startup",
+            func=dr.geom_friction,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "bar", geom_names=("bar_end_right_geom", "bar_end_left_geom")
+                ),
+                "operation": "scale",
+                "distribution": "uniform",
+                "axes": [0],
+                "ranges": (0.6, 1.4),
+            },
+        ),
+        "dr_bar_mass": EventTermCfg(
+            mode="startup",
+            func=dr.pseudo_inertia,
+            params={
+                "asset_cfg": SceneEntityCfg("bar", body_names=("bar",)),
+                "alpha_range": (-0.1, 0.1),
+            },
+        ),
+        # No actuator_names filter: dr.pd_gains indexes the grouped actuator
+        # configs rather than the individually-named joints every other dr
+        # function indexes, so a regex here silently produces out-of-range
+        # indices. Both arms are actuated in this task anyway.
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
             },
         ),
     }

--- a/src/openarm_mjlab/tasks/bimanual_lift/mdp.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/mdp.py
@@ -1,0 +1,830 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MDP terms for the OpenArm bimanual lift task.
+
+Bimanual lift task MDP: BOTH arms must squeeze-grip their own end of a
+
+long bar and raise it TOGETHER.
+
+This is the platform's first task where the LEFT arm is not parked via
+HoldDefaultPositionActionCfg -- see
+bimanual_lift_env_cfg.py's module docstring for the scene geometry and the
+collision-avoidance reasoning (both grip points sit well outside the
+centerline zone where the classical sibling project documented the two
+close-mounted arms' upper links colliding).
+
+Grip mechanics are copied verbatim from lift's hard-won, proven mechanism: both bar ends are lift's exact block geometry
+(50 mm box, mass 0.05, friction (2.5, 0.1, 0.01)), both fingers are raw
+effort-controlled with the same stiffened joint-limit spec, and the reward
+skeleton (reach / pinch / partial_pinch / pinch_streak / lift_rate capped at
+target / held_high / success bonus / descent+overshoot penalties) is the
+same shape lift shipped as `the single-arm lift task`.
+
+THE ONE GENUINELY NEW DESIGN QUESTION: how to define "together" so the task
+can't be solved by two independent single-arm lifts that happen to both
+succeed. Every reward/termination term below that credits HEIGHT or PINCH
+DURATION composes the two arms' signals with min(), not sum() or average():
+
+  - together_lift_rate_reward tracks progress of min(right_height,
+    left_height) -- a virtual "height of the lift" pinned to whichever end
+    is behind. If the right arm surges ahead while the left arm lags, the
+    surge earns nothing further until the left end catches up to that
+    level. sum()/average() would let a strong single-arm lift compensate
+    for a barely-lifted other end, which is exactly the "two independent
+    lifts" failure mode this task is supposed to rule out.
+  - together_pinch_streak_reward takes min(streak_right, streak_left):
+    either arm losing contact resets ITS streak to 0, which immediately
+    drags the paired reward back to 0 too -- streaks can only grow while
+    BOTH grips are simultaneously held, not merely each held at some point.
+  - level_reward is a dense, continuously-available companion (gated on
+    both grippers actually holding their end, per the note below) that
+    additionally discourages the bar tipping between the two height
+    checks above land on it.
+  - lifted_together (the success termination) requires both ends
+    independently inside the bounded height window (an earlier attempt/17's overshoot
+    lesson -- the project notes, "lifted_target ... has no upper bound")
+    AND a tighter LEVEL_TOLERANCE on their height difference than the
+    window width alone implies, so "both ends happened to be somewhere in
+    the 30 mm window at the same instant, 25 mm apart" cannot pass.
+
+reach_bar_end_reward and partial_pinch_reward stay UNGATED per arm (dense,
+summed): gating early shaping on the OTHER arm's progress would recreate
+the "gradient desert" an earlier attempt/9 already diagnosed (reach sitting near 1.0
+while pinch stays at 0.000) -- exploration needs to be able to discover
+each arm's own reach/one-pad-contact independently before the coordination
+requirement can mean anything.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv, quat_mul
+
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+from ...common_mdp import both_pads_on_block
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+# Table/height convention matches lift's TABLE_TOP_Z/BLOCK_START exactly
+# (same table entity, reused unmodified -- see get_lift_table_spec import
+# in bimanual_lift_env_cfg.py), declared independently here since the bar
+# is a different object, not lift's block.
+BAR_START = (0.30, 0.0, 0.43)
+TABLE_TOP_Z = 0.40
+
+# Local (bar-body-frame) offset of each grippable end from the bar's
+# center. Magnitude 0.16 m is not an arbitrary "order of 250-350mm bar"
+# guess -- it is copied directly from openarm_control/bimanual.py's
+# ParallelSort task (`right_jobs` pick_xy=(0.18, -0.16), simultaneously
+# with `left_jobs` at (0.18, +0.16)), the classical sibling project's own
+# PROVEN-safe simultaneous-bilateral-reach coordinate: both arms
+# genuinely operate at once at this separation without the upper-arm
+# collision the project's README documents for centered/shared targets
+# ("Two close-mounted 7-DOF arms collide when *both* reach over one
+# centred object"). It is independently corroborated by mjlab's own
+# right-arm workspace box (reach/mdp.py TARGET_LO/TARGET_HI: y in
+# [-0.35, -0.05]) -- -0.16 sits comfortably mid-range, nowhere near
+# either the centerline or the box edge. See the env cfg module
+# docstring for the full reasoning and the numbers checked.
+END_Y_OFFSET = 0.16
+RIGHT_END_OFFSET = (0.0, -END_Y_OFFSET, 0.0)
+LEFT_END_OFFSET = (0.0, END_Y_OFFSET, 0.0)
+
+TARGET_LIFT = 0.12  # m above start -- unchanged from lift: same actuators,
+# same per-arm load order of magnitude (each end's local grip only has to
+# resist roughly its own share of the bar's weight), no evidence to retune.
+MAX_LIFT_RATE = 0.3  # m/s
+SETTLED_SPEED = 0.10  # m/s bar speed for "held"
+HEIGHT_TOLERANCE = 0.03  # m -- success window is TARGET_LIFT..+30mm, per end
+# Tighter than HEIGHT_TOLERANCE on purpose: if it merely matched, it would
+# be a no-op (both ends already being inside the same 30mm window bounds
+# their difference to <=30mm anyway). At 15mm it is a genuine, independent
+# honesty gate -- e.g. right at +0mm-over-target and left at +30mm-over-
+# target both individually pass the window but are 30mm apart, which this
+# catches and the window check alone would not.
+LEVEL_TOLERANCE = 0.015  # m
+PINCH_STREAK_CAP = 25.0  # steps, same derivation as lift's (~0.5s, roughly
+# the time a real lift to TARGET_LIFT at MAX_LIFT_RATE would take).
+
+# An earlier attempt showed that individual_lift_rate_reward (an UNGATED per-arm bootstrap)
+# still never fired either -- neither arm ever discovers ANY upward
+# motion, ruling out coordination-gating as the specific bottleneck.
+# Mirrors lift's own history: lift needed reset_held_high (a curriculum
+# spawning some episodes already partway lifted) before genuine lifting
+# emerged, because pure from-scratch exploration of "squeeze AND raise"
+# is a narrow needle regardless of reward shape. Unlike lift, this task
+# had no IK-derived reference pose to build that curriculum on (both
+# arms use the generic HOME_KEYFRAME) -- solved for one here, using the
+# same OpenArmKinematics solver openarm_control/kinematics.py already
+# uses for the classical stack's own bimanual work, seeded at
+# HOME_KEYFRAME, targeting each end raised by HELD_HIGH_RAISE (0.08m,
+# matching lift's own choice -- below TARGET_LIFT so the policy still
+# has to finish the climb, not just hold at the goal). Converged
+# cleanly (error 0.046mm, first seed). Verified the classical stack's
+# own documented y=0-mirror identity (config.py's MIRROR_R2L, "verified
+# 0.000mm/0.000deg") holds for this pose too: solving the LEFT arm
+# independently and via q_left=MIRROR_R2L*q_right agreed to 1.4e-17
+# (floating-point exact) -- both are recorded below rather than only
+# trusting the mirror shortcut.
+HELD_HIGH_RAISE = 0.08  # m above BAR_START, matches lift's own reset_held_high
+# 2026-08-28 RE-SOLVED WITH THE ORIENTATION CONSTRAINED. The previous
+# values came from a POSITION-ONLY IK solve (see the "error 0.046mm" note
+# above -- millimetres, no angular term), so their wrist orientation was an
+# arbitrary artifact of the solver's null-space. Measured consequence
+# (probe_grasp_twist.py): the gripper rotates 57.6 deg mean along the path
+# from the policy's natural table grasp to this default pose. Since the
+# default pose IS the zero-action pose, that made a lift -- which "should"
+# be a pure relaxation toward default -- into a motion that twists the bar
+# out of the fingers, and it is the measured root cause of the never-lifts
+# plateau. Rewarding alignment instead was tried and regressed
+# (tested and reverted), because it fights kinematics rather than
+# fixing the reference.
+#
+# These are re-solved by solve_held_high_oriented.py: the orientation the
+# policy ACTUALLY adopts when grasping at the table, held fixed, at the
+# grasp position raised by HELD_HIGH_RAISE. Converged to 0.007mm position
+# AND 0.000 deg orientation error for both arms, seeded at the measured
+# grasp configuration so the solution stays in the same kinematic branch.
+# Default and grasp now differ by HEIGHT ALONE, so relaxing toward default
+# is a genuine vertical lift.
+#
+# NOTE: unlike the old values these are NOT an exact y-mirror pair. They are
+# derived from the policy's own grasp, which is not perfectly symmetric, so
+# the classical stack's MIRROR_R2L identity no longer applies here -- each
+# side is solved independently and that is deliberate.
+HELD_HIGH_RIGHT_Q = (
+    0.1060,
+    0.5567,
+    -0.0246,
+    1.4836,
+    0.5684,
+    0.0565,
+    1.0371,
+)
+HELD_HIGH_LEFT_Q = (
+    -0.2007,
+    -0.4367,
+    0.4452,
+    1.7822,
+    -0.5292,
+    -0.1500,
+    0.6359,
+)
+# An earlier attempt showed that a FIXED 50/50 mix of
+# "cold table start" and "already 67% up" never transferred cold-start
+# competence -- checked every checkpoint (500-2999), all 0%. The
+# curriculum episodes DID succeed (that's what drove the misleadingly
+# strong aggregate training-log numbers), just never generalized.
+# an earlier attempt then tried an ANNEALED version (spawn raise/probability
+# decaying linearly to 0 by HELD_HIGH_ANNEAL_STEPS) reasoning from
+# reverse-curriculum literature (Florensa et al. 2017) -- also 0% at
+# every checkpoint.
+#
+# 2026-08-23 root cause found (see the project notes, dated entry):
+# BOTH prior attempts moved the ROBOT'S JOINTS via write_joint_state_to_
+# sim while leaving the arm action terms' use_default_offset anchored to
+# the plain HOME_KEYFRAME (elbow-only neutral pose) -- because
+# JointPositionAction snapshots its _offset ONCE, at env-build time, from
+# entity.data.default_joint_pos, a per-episode write_joint_state_to_sim
+# call can move the PHYSICAL joint but never touches that offset. Direct
+# probe (scratchpad probe_yankback.py, zero action from a forced
+# held-high reset): right/left joint4 collapsed from 1.83 back toward
+# HOME_KEYFRAME's 1.57 within 3 steps, and h_together crashed from
+# 100mm to 30mm in 9 steps (~180ms) -- numerically the SAME "zero action
+# yanks the arm home, block drops in 160ms" signature lift's own review
+# #3 already diagnosed and fixed for the single-arm task (LIFT_HOME).
+# Control (same probe, offset monkey-patched to the held-high pose):
+# height held near 90-100mm the entire 40 steps, confirming the
+# actuator/gain setup itself is fine -- the bug is specifically the
+# offset/reset mismatch. This also explains an earlier attempt's own
+# unexplained late-training collapse: with maxh pre-set to the reset
+# height, a fall-then-partial-recover cycle earns ZERO new lift_rate
+# reward (new-progress-only, gated on the OLD high-water mark), so the
+# curriculum-assisted episodes were never actually rewarding the
+# intended "finish the climb" behavior, just the yank-and-recover
+# transient.
+#
+# Fix: mirror lift's OWN proven recipe exactly rather than re-inventing
+# a bimanual-specific curriculum shape. lift's LIFT_HOME IS its
+# HELD_HIGH_POSE (byte-identical joint values, per lift/mdp.py's own
+# comment: "Arm already at the held-high DEFAULT... only pin the
+# fingers... and place the block") -- the robot's DEFAULT pose is the
+# grip-ready pose, so zero action holds it, cold-table-start episodes
+# already hover right above the object, and reset_held_high only ever
+# needs to move the OBJECT, never the arm. Applied the same trick here:
+# get_bimanual_lift_robot_cfg's init_state now uses HELD_HIGH_RIGHT_Q/
+# LEFT_Q directly (already IK-solved, already verified <0.05mm error --
+# see below), and reset_bar_held_high (further down) no longer touches
+# the robot's joints at all. The old TABLE_RIGHT_Q/LEFT_Q (arm-at-table-
+# height IK solve, used only for the now-removed anneal's interpolation)
+# and the anneal schedule are removed as unneeded complexity fixing a
+# problem (permanent easy-mode exploitation) that was itself confounded
+# by this bug -- lift's own shipped config uses a FIXED, low probability
+# (0.15, see lift_env_cfg.py's reset_held_high wiring), which is the
+# only actually-proven ratio available, so that's what's reused here
+# rather than guessing a new one.
+HELD_HIGH_PROBABILITY = 0.15
+# Same block geometry as lift (verbatim), so lift's own proven squeeze
+# value transfers directly for the right finger; left is sign-mirrored
+# to match its mirrored joint range (0..0.7854 vs right's -0.7854..0,
+# confirmed in the XML -- see bimanual_lift_env_cfg.py's own actuator
+# comments).
+RIGHT_FINGER_SQUEEZE = -0.22
+LEFT_FINGER_SQUEEZE = 0.22
+
+
+def bar_pos_w(env, asset_cfg) -> torch.Tensor:
+    """Return the bar's world position."""
+    bar: Entity = env.scene[asset_cfg.name]
+    return bar.data.root_link_pos_w
+
+
+def bar_speed(env, asset_cfg) -> torch.Tensor:
+    """Return the bar's linear speed."""
+    bar: Entity = env.scene[asset_cfg.name]
+    return torch.linalg.norm(bar.data.root_link_vel_w[:, :3], dim=-1)
+
+
+def bar_end_pos_w(env, asset_cfg, local_offset) -> torch.Tensor:
+    """Return the world position of one bar end.
+
+    World position of one bar end: root pose + the end's LOCAL (body-
+
+    frame) offset, rotated by the bar's current orientation. Rotating the
+    offset (not just adding it in world frame) is what makes end_height
+    correctly reflect a TIPPED bar -- if only one end is genuinely held,
+    the free end drifts/tips rather than translating in lock-step, and this
+    keeps tracking its true world height through that rotation.
+    """
+    bar: Entity = env.scene[asset_cfg.name]
+    pos_w = bar.data.root_link_pos_w
+    quat_w = bar.data.root_link_quat_w
+    offset = torch.tensor(local_offset, device=pos_w.device).expand_as(pos_w)
+    return pos_w + quat_apply(quat_w, offset)
+
+
+def end_height(env, asset_cfg, local_offset) -> torch.Tensor:
+    """Return one bar end's height above its start."""
+    z = bar_end_pos_w(env, asset_cfg, local_offset)[:, 2]
+    return torch.clamp(z - BAR_START[2], min=0.0)
+
+
+def tool_pos_w(env, robot_cfg) -> torch.Tensor:
+    """Return the gripper tool point in world coordinates."""
+    robot: Entity = env.scene[robot_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    return ee_pos_w + quat_apply(ee_quat_w, offset)
+
+
+def tool_to_end_obs(env, robot_cfg, asset_cfg, local_offset) -> torch.Tensor:
+    """Return the tool-to-bar-end vector observation."""
+    robot: Entity = env.scene[robot_cfg.name]
+    vec_w = bar_end_pos_w(env, asset_cfg, local_offset) - tool_pos_w(env, robot_cfg)
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def reach_bar_end_reward(
+    env, std: float, robot_cfg, asset_cfg, local_offset
+) -> torch.Tensor:
+    """Return dense per-arm reach shaping toward one bar end.
+
+    Dense per-arm reach shaping, deliberately NOT gated on the other
+
+    arm's progress -- see module docstring.
+    """
+    vec = tool_to_end_obs(env, robot_cfg, asset_cfg, local_offset)
+    d2 = torch.sum(torch.square(vec), dim=-1)
+    return torch.exp(-d2 / std**2)
+
+
+def pinch_reward(env, sensor_name: str) -> torch.Tensor:
+    """Return 1.0 where both finger pads touch the bar end."""
+    return both_pads_on_block(env, sensor_name).float()
+
+
+def partial_pinch_reward(env, sensor_name: str) -> torch.Tensor:
+    """Return 0, 0.5 or 1.0 for how many of the two pads are touching.
+
+    A graded predecessor to the binary two-pad gate: the binary AND gives no
+    signal for "one pad landed, still working on the other", a gradient
+    desert that stalls discovery of the squeeze. Purely additive -- success
+    and termination still require a genuine two-pad pinch.
+    """
+    sensor = env.scene[sensor_name]
+    found = sensor.data.found
+    assert found is not None
+    per_pad = (found.view(env.num_envs, 2, -1).amax(dim=-1) > 0).float()
+    return per_pad.mean(dim=-1)
+
+
+def pinch_obs(env, sensor_name: str) -> torch.Tensor:
+    """Return the observation wrapper for the two-pad pinch gate."""
+    return both_pads_on_block(env, sensor_name).float().unsqueeze(-1)
+
+
+def both_ends_gripped(env, sensor_right: str, sensor_left: str) -> torch.Tensor:
+    """Return True where both grippers hold their own bar end.
+
+    Both grippers independently satisfy lift's proven two-pad pinch gate
+
+    on their own end. Reused directly (not reimplemented) from lift.mdp:
+    both_pads_on_block is fully generic given a sensor_name -- it carries no
+    hidden per-task state, so calling it twice (once per side) is safe.
+    """
+    return both_pads_on_block(env, sensor_right) & both_pads_on_block(env, sensor_left)
+
+
+def _streak_buffers(env) -> dict[str, torch.Tensor]:
+    if not hasattr(env, "_bimanual_lift_streaks"):
+        env._bimanual_lift_streaks = {
+            "right": torch.zeros(env.num_envs, device=env.device),
+            "left": torch.zeros(env.num_envs, device=env.device),
+        }
+    return env._bimanual_lift_streaks
+
+
+# 2026-08-26 grasp-geometry fix. Measured root cause of the never-lifts
+# plateau (probe_grasp_geometry.py, full trail in the project notes): at
+# the instant a two-ended grasp forms, the TABLE grasp contacts the end
+# block at a mean vertical offset of +18.4mm, while the held-high (pinned)
+# grasp -- the one that demonstrably survives a lift -- sits at -2.4mm,
+# essentially centred. The block's half-height is 30mm, so the table grasp
+# clamps ~61% of the way up toward the TOP edge, and only about half as
+# deep (0.9mm vs 1.9mm penetration). That is a peel-off geometry: under
+# lift acceleration the block pivots about the shallow high contact and
+# escapes, which is exactly what the scripted-lift probe measured (force
+# decaying to 0.00N by 40mm of lift, versus 30.6N retained from the
+# held-high grasp under an identical command).
+#
+# It is NOT a force problem -- static holding force is essentially equal
+# in both cases (29.4N vs 32.8N) against a ~1.2N bar, a hypothesis that
+# was measured and refuted before this one. It is purely WHERE the fingers
+# land, and nothing in the reward ever distinguished that: `pinch_reward`
+# is `both_pads_on_block(...)`, binary presence of any contact, so a
+# shallow grab at the top edge scored exactly what a centred, deep grasp
+# scored. The arm's default pose is above the bar, so descending and
+# catching the top is the first thing that satisfies the sensor, and the
+# policy had no reason to look for anything better.
+# Sized so the CURRENT (failing) grasp sits mid-curve, not in the flat
+# tail. Measured table-grasp offset is +18.4mm; at std=0.012 that scores
+# 0.005, i.e. the policy would start in a gradient desert -- the exact
+# failure mode lift's own r3b binary-gate fix had to remove. At 0.022 the
+# same grasp scores ~0.50, a centred grasp 1.0, and the held-high
+# reference ~0.78, so there is real gradient across the whole range the
+# policy actually operates in.
+GRASP_CENTRE_STD = 0.022  # m
+GRASP_QUALITY_FLOOR = 0.4  # keep some income for ANY grasp (see below)
+
+
+# 2026-08-26, measured (probe_grasp_twist.py): along the joint-space path
+# from the grasp pose toward the default pose, the gripper ROTATES by 57.6
+# deg on average (max 74.9). That is enough to wrench the bar out of a
+# parallel-jaw grasp, and it explains the two failure modes of every
+# scripted lift attempted: a slow rise gives the twist time to work the bar
+# loose (it slips away by 25mm), while a fast rise outruns the twist but
+# arrives ballistically (whenever both ends are inside the success window,
+# grip has already been lost -- win_grip measured at exactly 0.000).
+#
+# The cause is that the policy's self-established table grasp adopts a wrist
+# orientation ~58 deg away from the one the default/held-high pose uses. So
+# "lift" is NOT the simple relaxation toward default that the action space
+# would otherwise make it -- the policy would have to learn a coordinated
+# joint motion that raises the bar WHILE actively counter-rotating the
+# wrist, which is far harder than relaxing toward zero action.
+#
+# These are the EE orientations at the default (held-high) pose, measured
+# directly from the compiled scene. Rewarding the grasp to align with them
+# makes lifting a relaxation again.
+DEFAULT_EE_QUAT_RIGHT = (-0.6449, 0.0080, 0.7638, -0.0255)
+DEFAULT_EE_QUAT_LEFT = (-0.6488, 0.0007, 0.7587, 0.0579)
+# Sized so the CURRENT ~58 deg (1.01 rad) misalignment scores ~0.5 rather
+# than sitting in the flat tail of the Gaussian. An earlier grasp-centring
+# term had exactly that gradient-desert bug at too tight a width, so the
+# width here is set from the measurement rather than guessed.
+GRASP_ORIENT_STD = 1.2  # rad
+
+
+def grasp_orientation_reward(env, robot_cfg, target_quat) -> torch.Tensor:
+    """Reward the gripper for holding the default pose's orientation.
+
+    Aligning the grasp with the held-high orientation is what makes a lift a
+    pure relaxation toward the default pose, instead of a motion that twists
+    the bar out of the fingers on the way up.
+    """
+    robot: Entity = env.scene[robot_cfg.name]
+    q = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    tq = torch.tensor(target_quat, device=q.device, dtype=q.dtype).expand_as(q)
+    dq = quat_mul(q, quat_inv(tq))
+    ang = 2.0 * torch.acos(dq[:, 0].abs().clamp(max=1.0))
+    return torch.exp(-((ang / GRASP_ORIENT_STD) ** 2))
+
+
+def grasp_centring(env, sensor_name: str, asset_cfg, local_offset) -> torch.Tensor:
+    """0..1 measure of how vertically centred the grasp is on its end block.
+
+    Contact points are expressed in the BAR's own frame (not world) so this
+    stays correct when the bar tips, matching bar_end_pos_w's reasoning.
+    """
+    bar: Entity = env.scene[asset_cfg.name]
+    sensor_data = env.scene[sensor_name].data
+    pos = sensor_data.pos
+    if pos is None:
+        return torch.ones(env.num_envs, device=env.device)
+    end_w = bar_end_pos_w(env, asset_cfg, local_offset)
+    rel_w = pos.mean(dim=1) - end_w
+    rel_b = quat_apply(quat_inv(bar.data.root_link_quat_w), rel_w)
+    return torch.exp(-((rel_b[:, 2] / GRASP_CENTRE_STD) ** 2))
+
+
+def quality_pinch_reward(
+    env, sensor_name: str, asset_cfg, local_offset
+) -> torch.Tensor:
+    """Binary pinch, scaled by how centred the grasp is.
+
+    TESTED AND REGRESSED, kept for the record and for diagnostics -- NOT
+    wired into the reward dict. `an earlier attempt` used this (plus
+    the same weighting on the streak term) and both-ends-gripped collapsed
+    from 0.93 to 0.000: multiplying the two terms that actually taught
+    gripping cut up to 1.5/step of income, and the policy abandoned the
+    behaviour rather than improving it. The floor of 0.4 was not enough.
+    The working approach instead leaves grip income alone and fixes the
+    saturated REACH term (see reach_fine_* in the env cfg), which is what
+    actually determines where the fingers land before the grasp forms.
+
+    Deliberately a MULTIPLIER on the existing pinch income rather than a new
+    additive term: this task's whole difficulty is that grip-and-sit income
+    already outbids lifting (see the success-bonus arithmetic in
+    bimanual_lift_env_cfg.py), so adding another term payable while camping
+    would make that worse. Redistributing the SAME budget toward good grasps
+    adds the missing gradient without raising the camping ceiling at all --
+    a bad grasp now earns strictly less than it used to, a centred one earns
+    what it always did.
+
+    The floor keeps a poor grasp worth something, so the already-solid
+    gripping behaviour (0.85-0.97 both-ends-gripped, hard-won via the
+    squeeze-scale fix) is shaped rather than destabilised.
+    """
+    gripped = both_pads_on_block(env, sensor_name).float()
+    q = grasp_centring(env, sensor_name, asset_cfg, local_offset)
+    return gripped * (GRASP_QUALITY_FLOOR + (1.0 - GRASP_QUALITY_FLOOR) * q)
+
+
+def together_pinch_streak_reward(
+    env, sensor_right: str, sensor_left: str
+) -> torch.Tensor:
+    r"""Return a reward for holding BOTH grips simultaneously over time.
+
+    Paired version of the single-arm pinch-streak reward. An earlier attempt showed that a policy that pecked -- 2-step grab/release cycles --
+    scored identically to a genuine hold under the old binary pinch/
+    partial_pinch rewards; sustaining duration had to be made to pay
+    directly). Two independent per-arm streaks are tracked (each resets to
+    0 the instant THAT arm's own contact breaks), and the credited reward is
+    min(streak_right, streak_left) -- so a policy that holds the right grip
+    for 20 steps while pecking the left grip for 2 gets credit for only a
+    2-step streak, not 20. This is what actually enforces "held together,"
+    not just "each held for a while, not necessarily overlapping.\"
+    """
+    streaks = _streak_buffers(env)
+    gripped_r = both_pads_on_block(env, sensor_right)
+    gripped_l = both_pads_on_block(env, sensor_left)
+    sr, sl = streaks["right"], streaks["left"]
+    sr[gripped_r] += 1.0
+    sr[~gripped_r] = 0.0
+    sl[gripped_l] += 1.0
+    sl[~gripped_l] = 0.0
+    paired = torch.minimum(sr, sl)
+    return torch.clamp(paired / PINCH_STREAK_CAP, 0.0, 1.0)
+
+
+def _max_together_height(env) -> torch.Tensor:
+    if not hasattr(env, "_bimanual_lift_max_h"):
+        env._bimanual_lift_max_h = torch.zeros(env.num_envs, device=env.device)
+    return env._bimanual_lift_max_h
+
+
+def together_lift_rate_reward(
+    env, sensor_right: str, sensor_left: str, asset_cfg
+) -> torch.Tensor:
+    """Return a reward for new upward progress of the lower bar end.
+
+    Paired version of the single-arm lift-rate reward. a plain
+
+    rise-rate reward is bounce-farmable; new-progress-only pays each mm
+    once, and per an earlier attempt's fix, credited progress is capped at TARGET_LIFT
+    so nothing rewards climbing past the intended window).
+
+    The coordination step: progress is measured on h_together =
+    min(right_height, left_height), a single virtual "height of the lift"
+    pinned to whichever end is behind, THEN the same new-progress-only/
+    capped-at-target logic lift already proved runs on that one scalar. If
+    the right end is 80mm up and the left end is 20mm up, h_together is
+    20mm -- the right arm's additional height earns nothing further until
+    the left arm brings its end up to match. This is what forces the
+    policy to bring the lagging arm along rather than banking progress on
+    whichever arm happens to be easier.
+    """
+    h_r = end_height(env, asset_cfg, RIGHT_END_OFFSET)
+    h_l = end_height(env, asset_cfg, LEFT_END_OFFSET)
+    h_together = torch.minimum(h_r, h_l)
+    maxh = _max_together_height(env)
+    h_capped = torch.clamp(h_together, max=TARGET_LIFT)
+    maxh_capped = torch.clamp(maxh, max=TARGET_LIFT)
+    new = torch.clamp(h_capped - maxh_capped, min=0.0)
+    maxh.copy_(torch.maximum(maxh, h_together))
+    rate = torch.clamp(new / env.step_dt, 0.0, MAX_LIFT_RATE) / MAX_LIFT_RATE
+    gate = both_ends_gripped(env, sensor_right, sensor_left).float()
+    return rate * gate
+
+
+def _max_individual_height(env, side: str) -> torch.Tensor:
+    attr = f"_bimanual_lift_max_h_{side}"
+    if not hasattr(env, attr):
+        setattr(env, attr, torch.zeros(env.num_envs, device=env.device))
+    return getattr(env, attr)
+
+
+def individual_lift_rate_reward(
+    env, sensor_name: str, asset_cfg, local_offset, side: str
+) -> torch.Tensor:
+    """Bootstrapping companion to together_lift_rate_reward.
+
+    2026-08-20, first real training run's postmortem: by iteration ~200-500 the policy
+    fully solved reach/grip/streak/level, then went completely flat for
+    2500+ more iterations -- together_lift_rate_reward and
+    together_held_high_reward stayed at exact zero the whole time. Root
+    cause: both are gated on h_together = min(right,left), so from a
+    cold start at height 0, BOTH arms' exploration noise has to
+    coincidentally push upward in the SAME step before any lift reward
+    appears at all -- a much narrower needle than lift's own single-arm
+    problem ever was.
+
+    This mirrors the reasoning already used for reach_bar_end_reward and
+    partial_pinch_reward (module docstring: deliberately UNGATED per arm
+    so "exploration needs to be able to discover each arm's own reach/
+    one-pad-contact independently before the coordination requirement
+    can mean anything") -- extended one step further, to the lift motion
+    itself, which previously had no individual/ungated version to
+    bootstrap from. Gated only on THIS arm's own grip (not both), so
+    each arm can discover "lifting my own end is possible" on its own.
+
+    Weighted much lower than together_lift_rate_reward in the env cfg
+    (kept as the dominant channel) specifically so this can only ever
+    help escape the flat-zero plateau, not replace the coordination
+    requirement -- genuine success still requires together_* to fire.
+    """
+    h = end_height(env, asset_cfg, local_offset)
+    maxh = _max_individual_height(env, side)
+    h_capped = torch.clamp(h, max=TARGET_LIFT)
+    maxh_capped = torch.clamp(maxh, max=TARGET_LIFT)
+    new = torch.clamp(h_capped - maxh_capped, min=0.0)
+    maxh.copy_(torch.maximum(maxh, h))
+    rate = torch.clamp(new / env.step_dt, 0.0, MAX_LIFT_RATE) / MAX_LIFT_RATE
+    gate = both_pads_on_block(env, sensor_name).float()
+    return rate * gate
+
+
+def together_held_high_reward(
+    env, sensor_right: str, sensor_left: str, asset_cfg
+) -> torch.Tensor:
+    """Return a graded reward for holding both ends near the target height.
+
+    Paired version of the single-arm held-high reward: graded height-holding income, avoiding the binary-gate gradient desert lift's r3b fix
+    addressed). Uses the same h_together = min(...) composition as
+    together_lift_rate_reward, for the same reason.
+    """
+    h_r = end_height(env, asset_cfg, RIGHT_END_OFFSET)
+    h_l = end_height(env, asset_cfg, LEFT_END_OFFSET)
+    h_together = torch.minimum(h_r, h_l)
+    frac = torch.clamp(h_together / TARGET_LIFT, 0.0, 1.0)
+    return frac * both_ends_gripped(env, sensor_right, sensor_left).float()
+
+
+def level_reward(
+    env, sensor_right: str, sensor_left: str, asset_cfg, std: float = 0.03
+) -> torch.Tensor:
+    """Return a reward for keeping the bar horizontal while gripped.
+
+    Dense Gaussian shaping on the height DIFFERENCE between the two
+
+    ends, encouraging the bar to stay roughly horizontal throughout the
+    climb (not just at the final success check, where lifted_together's
+    LEVEL_TOLERANCE already gates it).
+
+    Gated on both_ends_gripped for the same reason review finding 5 (drawer:
+    "with randomized initial opening, absolute-opening rewards pay free
+    income at spawn") flags absolute/state-based terms with no engagement
+    requirement: at rest, both ends sit at height 0 and are trivially
+    "level" (kernel = 1.0) before any grasping has happened at all.
+
+    2026-08-26: that grip gate turned out NOT to be sufficient, and this
+    term was a real camping-income bug -- the exact class it was written
+    to avoid. A bar resting flat ON THE TABLE has h_r == h_l == 0, so the
+    kernel is a perfect 1.0, and the grip gate is trivially satisfied by
+    closing both grippers on it without lifting at all. Measured directly
+    in `an earlier attempt`'s training log: `Episode_Reward/level`
+    climbed to 0.847 while the hardened eval of that same policy showed a
+    max bar height of 0.3mm -- i.e. ~0.85/step of steady income, for the
+    whole episode, for gripping a bar and leaving it exactly where it
+    was. That is a meaningful share of the ~6/step camping income this
+    task's success bonus has to outbid, and unlike reach/pinch (which at
+    least pay for genuinely necessary sub-skills) this one paid for a
+    literal non-behavior.
+
+    Fix: scale by the achieved height fraction, the same shape
+    together_held_high_reward already uses. At table height this is 0 (no
+    free income); at TARGET_LIFT it is full -- preserving the intended
+    "stay horizontal DURING the climb" shaping while removing the
+    stay-put income. Deliberately a smooth scale rather than a hard
+    height threshold, which would reintroduce the binary-gate gradient
+    desert lift's own r3b fix had to remove.
+    """
+    h_r = end_height(env, asset_cfg, RIGHT_END_OFFSET)
+    h_l = end_height(env, asset_cfg, LEFT_END_OFFSET)
+    kernel = torch.exp(-(((h_r - h_l) / std) ** 2))
+    frac = torch.clamp(torch.minimum(h_r, h_l) / TARGET_LIFT, 0.0, 1.0)
+    return kernel * frac * both_ends_gripped(env, sensor_right, sensor_left).float()
+
+
+def bar_descent_penalty(env, asset_cfg) -> torch.Tensor:
+    """Return a penalty for lowering the bar.
+
+    Anti-pump, matching lift's block_descent_penalty exactly: lowering
+
+    the bar is never free.
+    """
+    bar: Entity = env.scene[asset_cfg.name]
+    return torch.clamp(-bar.data.root_link_vel_w[:, 2], min=0.0)
+
+
+def together_overshoot_penalty(env, asset_cfg) -> torch.Tensor:
+    r"""Return a penalty for raising the bar past the target window.
+
+    Paired version of the single-arm overshoot penalty. capping lift_rate's income stopped REWARDING overshoot but left it
+    reward-neutral, and median max-height stayed ~658mm anyway; this makes
+    exceeding the window actively costly). Fires on h_together = min(...),
+    so a bar tipped up on only one side (the other end still near the
+    table) never counts as "the coordinated lift overshooting.\"
+    """
+    h_r = end_height(env, asset_cfg, RIGHT_END_OFFSET)
+    h_l = end_height(env, asset_cfg, LEFT_END_OFFSET)
+    h_together = torch.minimum(h_r, h_l)
+    return torch.clamp(h_together - (TARGET_LIFT + HEIGHT_TOLERANCE), min=0.0)
+
+
+def together_success_bonus(env) -> torch.Tensor:
+    """Fire once on the successful-lift termination step."""
+    return env.termination_manager.get_term("lifted_together").float()
+
+
+def lifted_together(
+    env, sensor_right: str, sensor_left: str, asset_cfg
+) -> torch.Tensor:
+    """Success: BOTH ends independently inside the bounded TARGET_LIFT..
+
+    +HEIGHT_TOLERANCE window (an earlier attempt/17's overshoot-termination fix,
+    applied per end rather than lift's single scalar -- the project notes:
+    an unbounded `height >= TARGET_LIFT` check let a genuinely-lifting
+    policy sail hundreds of mm past the intended target since nothing
+    penalized going higher and the one-time success bonus dwarfed the
+    forgone shaping reward), settled, both grips genuinely holding, AND
+    level (see LEVEL_TOLERANCE's docstring above for why this is a real,
+    non-redundant additional check at these parameter values, not implied
+    by the window bound alone).
+    """
+    h_r = end_height(env, asset_cfg, RIGHT_END_OFFSET)
+    h_l = end_height(env, asset_cfg, LEFT_END_OFFSET)
+    in_window_r = (h_r >= TARGET_LIFT) & (h_r <= TARGET_LIFT + HEIGHT_TOLERANCE)
+    in_window_l = (h_l >= TARGET_LIFT) & (h_l <= TARGET_LIFT + HEIGHT_TOLERANCE)
+    level = (h_r - h_l).abs() < LEVEL_TOLERANCE
+    slow = bar_speed(env, asset_cfg) < SETTLED_SPEED
+    gripped = both_ends_gripped(env, sensor_right, sensor_left)
+    return in_window_r & in_window_l & level & slow & gripped
+
+
+def bar_fell(env, asset_cfg) -> torch.Tensor:
+    """Return True where the bar has dropped below the floor threshold.
+
+    Fell if the bar's center OR either end drops below the floor
+
+    threshold (lift's block_fell used a single point since its block has
+    no meaningful extent; the bar can tip, so checking only the center
+    could miss an end that slid off the table edge while the center
+    stayed higher).
+    """
+    center_z = bar_pos_w(env, asset_cfg)[:, 2]
+    right_z = bar_end_pos_w(env, asset_cfg, RIGHT_END_OFFSET)[:, 2]
+    left_z = bar_end_pos_w(env, asset_cfg, LEFT_END_OFFSET)[:, 2]
+    lowest = torch.minimum(torch.minimum(center_z, right_z), left_z)
+    return lowest < 0.30
+
+
+def reset_bar_uniform(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    xy_range: float = 0.03,
+) -> None:
+    """Raw-coords free-body reset, matching lift's reset_block_uniform.
+
+    xy_range=0.03 (lift's proven value) reused as-is: worst case it shifts
+    an end's y from -0.16 to -0.13, still well clear of the centerline
+    collision zone the env cfg docstring documents avoiding (a few mm of
+    jitter is not the same regime as reaching toward y=0).
+    """
+    bar: Entity = env.scene[asset_cfg.name]
+    default = bar.data.default_root_state
+    assert default is not None
+    state = default[env_ids].clone()
+    n = len(env_ids)
+    state[:, 0] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 1] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 7:] = 0.0
+    bar.write_root_state_to_sim(state, env_ids=env_ids)
+    _max_together_height(env)[env_ids] = 0.0
+    _max_individual_height(env, "right")[env_ids] = 0.0
+    _max_individual_height(env, "left")[env_ids] = 0.0
+    streaks = _streak_buffers(env)
+    streaks["right"][env_ids] = 0.0
+    streaks["left"][env_ids] = 0.0
+
+
+def reset_bar_held_high(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    robot_joints_cfg: SceneEntityCfg,
+    probability: float = HELD_HIGH_PROBABILITY,
+) -> None:
+    """Reset a fraction of episodes with the bar already raised.
+
+    Bimanual version of lift's reset_held_high -- rewritten 2026-08-23
+
+    to fix the yank-back bug (see HELD_HIGH_PROBABILITY's docstring above
+    for the full diagnosis and the probe that confirmed it).
+
+    Now mirrors lift's actual mechanism exactly, not just its intent: the
+    robot's default pose (get_bimanual_lift_robot_cfg's init_state, fixed
+    in this same commit) IS the held-high pose, so reset_robot_joints'
+    own jitter already puts the arm there for every episode, every time,
+    with zero action holding it -- this function only needs to pin the
+    fingers to their squeeze width and place the BAR at the held height,
+    exactly like lift's reset_held_high does for the block. No arm-joint
+    writes, no interpolation, no annealing: with the yank-back gone, a
+    fixed low probability (lift's own proven 0.15) is the only tested
+    ratio, so that's what's used rather than re-guessing a schedule.
+
+    Runs AFTER reset_bar_uniform (overrides the subset for the picked
+    envs; streak buffers are left as reset_bar_uniform set them, matching
+    lift's own precedent of not separately touching them here).
+    """
+    if probability <= 0.0:
+        return
+    robot: Entity = env.scene[robot_joints_cfg.name]
+    bar: Entity = env.scene[asset_cfg.name]
+    pick = torch.rand(len(env_ids), device=env.device) < probability
+    ids = env_ids[pick]
+    if len(ids) == 0:
+        return
+    jp = robot.data.joint_pos[ids].clone()
+    jv = torch.zeros_like(robot.data.joint_vel[ids])
+    for j, jname in enumerate(robot.joint_names):
+        if "right_finger" in jname:
+            jp[:, j] = RIGHT_FINGER_SQUEEZE
+        if "left_finger" in jname:
+            jp[:, j] = LEFT_FINGER_SQUEEZE
+    robot.write_joint_state_to_sim(jp, jv, env_ids=ids)
+    state = bar.data.default_root_state[ids].clone()
+    state[:, 0] = BAR_START[0]
+    state[:, 1] = BAR_START[1]
+    state[:, 2] = BAR_START[2] + HELD_HIGH_RAISE
+    state[:, 3:7] = torch.tensor([1.0, 0.0, 0.0, 0.0], device=env.device)
+    state[:, 7:] = 0.0
+    bar.write_root_state_to_sim(state, env_ids=ids)
+    # Height buffers: credit only NEW height above the spawn hold (exact
+    # match to lift's own reset_held_high comment: "credit only NEW
+    # height above the spawn hold").
+    _max_together_height(env)[ids] = HELD_HIGH_RAISE
+    _max_individual_height(env, "right")[ids] = HELD_HIGH_RAISE
+    _max_individual_height(env, "left")[ids] = HELD_HIGH_RAISE

--- a/src/openarm_mjlab/tasks/bimanual_lift/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/bimanual_lift/rl_cfg.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm bimanual lift task.
+
+Hyperparameters are the same ones the single-arm lift task uses; only the
+reward and environment design differ between the two.
+"""
+
+from mjlab.rl import (
+    RslRlModelCfg,
+    RslRlOnPolicyRunnerCfg,
+    RslRlPpoAlgorithmCfg,
+)
+
+
+def openarm_bimanual_lift_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Build the PPO runner config for the bimanual lift task."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            # Raising this was tried (0.03) to break the plateau where reach
+            # and grip saturate while the lift signal stays flat. It neither
+            # unlocked lifting nor cost grip precision, so the proven value
+            # is kept.
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        # The two finger actuators are genuinely identical in the asset
+        # (both capped at 7 N*m, verified against the compiled model), so
+        # their action scales match; an earlier asymmetric scale gave the
+        # left gripper ~43% more effective torque per unit of policy output
+        # and produced a lopsided grasp. See LEFT/RIGHT_SQUEEZE_SCALE.
+        experiment_name="openarm_bimanual_lift",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=3_000,
+    )

--- a/tests/test_bimanual_lift_env.py
+++ b/tests/test_bimanual_lift_env.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-BimanualLift environment.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+OBS_DIM = 18 + 18 + 3 + 3 + 1 + 1 + 16  # joint_pos, joint_vel,
+# tool_to_right_end, tool_to_left_end, pinch_right, pinch_left, actions
+
+# Unlike the other tasks in this suite, BOTH arms are actively controlled:
+# two 7-dim arm terms plus two 1-dim finger-effort terms.
+ACTION_DIM = 7 + 7 + 1 + 1
+
+
+def test_task_is_registered():
+    assert "OpenArm-BimanualLift" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-BimanualLift")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == ACTION_DIM
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_both_arms_are_actuated(env):
+    """Both arms must be controllable; neither is parked.
+
+    This is what distinguishes the task from the rest of the suite, where one
+    arm is servo-held at its default pose, so it is worth asserting rather
+    than assuming.
+    """
+    names = list(env.action_manager._terms.keys())
+    assert "right_arm" in names
+    assert "left_arm" in names
+    assert "right_squeeze" in names
+    assert "left_squeeze" in names
+
+
+def test_bar_starts_on_the_table():
+    """The bar must rest at its table height on an unassisted reset.
+
+    Built with its own env rather than the shared fixture: the task's
+    curriculum deliberately spawns a fraction of episodes with the bar
+    already raised, so asserting the table height against the default
+    config would be flaky.
+    """
+    from mjlab.envs import ManagerBasedRlEnv
+
+    from openarm_mjlab.tasks.bimanual_lift import mdp as bl_mdp
+
+    cfg = load_env_cfg("OpenArm-BimanualLift")
+    cfg.scene.num_envs = 2
+    cfg.events["reset_bar_held_high"].params["probability"] = 0.0
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    try:
+        env.reset()
+        z = env.scene["bar"].data.root_link_pos_w[:, 2]
+        assert torch.allclose(z, torch.tensor(bl_mdp.BAR_START[2]), atol=0.02)
+    finally:
+        env.close()
+
+
+def test_success_requires_both_ends_not_just_one(env):
+    """`lifted_together` must not be satisfiable by a single-arm lift.
+
+    The height terms compose the two ends with min(), so a policy that raises
+    one end while the other stays down earns nothing -- the property the task
+    exists to enforce.
+    """
+    from openarm_mjlab.tasks.bimanual_lift import mdp as bl_mdp
+
+    assert bl_mdp.LEVEL_TOLERANCE < bl_mdp.HEIGHT_TOLERANCE
+    assert bl_mdp.HELD_HIGH_RAISE < bl_mdp.TARGET_LIFT


### PR DESCRIPTION
Both arms grip their own end of a 370mm bar and raise it together into a bounded height window. This is the first task in the suite where both arms are actively controlled rather than one being servo-held, so it uses four action terms (two 7-dim arm terms plus two 1-dim finger-effort terms) and 16 action dimensions.

The design question specific to this task is how to define "together" so it can't be solved as two independent single-arm lifts that happen to both succeed. Every term crediting height or grip duration composes the two arms with min() rather than a sum or average i.e if one end surges ahead, the surge earns nothing until the other catches up. The success termination additionally requires both ends inside the height window and a tighter level tolerance on their difference.

**Results:** 100% clean success over 256 held-out table-start episodes, 0% drops, heights 131.7mm / 130.5mm per end (window 120-150mm).

As with the lift PR, that figure comes from evaluating a reference policy inside this environment rather than one trained in this repo — it's a direct check that the port is behaviourally correct. The policy itself was solved and confirmed on two independent seeds.

**Tests:** `tests/test_bimanual_lift_env.py`, 6/6 passing: task registration, action/observation dimensions, finite-signal stepping, that both arms are genuinely actuated (neither parked), that the bar starts on the table, and that success can't be satisfied by a single-arm lift.