### PR TITLE
Add a shared multi-task policy across five tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Issues = "https://github.com/enactic/openarm_mjlab/issues"
 Repository = "https://github.com/enactic/openarm_mjlab"
 
 [project.scripts]
+openarm-mjlab-multitask-train = "openarm_mjlab.multitask_train:main"
 openarm-mjlab-play = "openarm_mjlab.play:main"
 openarm-mjlab-train = "openarm_mjlab.train:main"
 

--- a/src/openarm_mjlab/multitask_train.py
+++ b/src/openarm_mjlab/multitask_train.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Train one policy on all five MultiTask environments concurrently.
+
+Unlike ``openarm-mjlab-train``, which trains a single registered task, this
+builds a mixture environment holding every task at once so each PPO batch
+spans all five. See ``openarm_mjlab.tasks.multitask`` for why.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+from dataclasses import asdict
+from pathlib import Path
+
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  (registers the tasks)
+from mjlab.rl import MjlabOnPolicyRunner
+from mjlab.tasks.registry import load_rl_cfg
+from openarm_mjlab.tasks.multitask.mixture_env import (
+    MULTITASK_IDS,
+    MultiTaskMixtureVecEnv,
+)
+
+
+def train(
+    num_envs: int,
+    iterations: int,
+    experiment: str | None,
+    seed: int,
+    weights: tuple[float, ...] | None,
+    device: str,
+    logger: str | None = None,
+) -> Path:
+    """Train the shared policy and return the run's log directory."""
+    torch.manual_seed(seed)
+    env = MultiTaskMixtureVecEnv(
+        num_envs_total=num_envs, device=device, weights=weights
+    )
+    allocation = {task.split("-")[-1]: n for task, n in zip(MULTITASK_IDS, env.counts)}
+    print(f"per-task environments: {allocation}", flush=True)
+
+    agent_cfg = load_rl_cfg(MULTITASK_IDS[0])
+    agent_cfg.max_iterations = iterations
+    agent_cfg.seed = seed
+    if experiment:
+        agent_cfg.experiment_name = experiment
+    if logger:
+        agent_cfg.logger = logger
+
+    log_dir = (
+        Path("logs/rsl_rl")
+        / agent_cfg.experiment_name
+        / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    )
+    log_dir.mkdir(parents=True, exist_ok=True)
+    print(f"logging to {log_dir}", flush=True)
+
+    runner = MjlabOnPolicyRunner(env, asdict(agent_cfg), str(log_dir), device=device)
+    runner.learn(num_learning_iterations=iterations, init_at_random_ep_len=True)
+    env.close()
+    return log_dir
+
+
+def main() -> None:
+    """Parse arguments and run one concurrent multi-task training job."""
+    parser = argparse.ArgumentParser(
+        prog="openarm-mjlab-multitask-train",
+        description=__doc__.split("\n")[0],
+    )
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=1000,
+        help="total environments, split across the five tasks (default: 1000)",
+    )
+    parser.add_argument("--iterations", type=int, default=3000)
+    parser.add_argument(
+        "--experiment",
+        default=None,
+        help="experiment name (default: the one in the task's rl_cfg)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--weights",
+        default=None,
+        help=(
+            "comma-separated allocation weights in task order "
+            f"({', '.join(t.split('-')[-1] for t in MULTITASK_IDS)}); "
+            "default is an even split"
+        ),
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument(
+        "--logger",
+        choices=("wandb", "tensorboard"),
+        default=None,
+        help="override the run's logger (default: whatever the rl_cfg sets)",
+    )
+    args = parser.parse_args()
+
+    weights = tuple(float(w) for w in args.weights.split(",")) if args.weights else None
+    train(
+        args.num_envs,
+        args.iterations,
+        args.experiment,
+        args.seed,
+        weights,
+        args.device,
+        args.logger,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openarm_mjlab/tasks/__init__.py
+++ b/src/openarm_mjlab/tasks/__init__.py
@@ -16,6 +16,7 @@
 
 from . import door  # noqa: F401
 from . import drawer  # noqa: F401
+from . import multitask  # noqa: F401
 from . import pick_place  # noqa: F401
 from . import puck  # noqa: F401
 from . import reach  # noqa: F401

--- a/src/openarm_mjlab/tasks/__init__.py
+++ b/src/openarm_mjlab/tasks/__init__.py
@@ -17,5 +17,6 @@
 from . import door  # noqa: F401
 from . import drawer  # noqa: F401
 from . import pick_place  # noqa: F401
+from . import puck  # noqa: F401
 from . import reach  # noqa: F401
 from . import valve  # noqa: F401

--- a/src/openarm_mjlab/tasks/multitask/__init__.py
+++ b/src/openarm_mjlab/tasks/multitask/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One shared policy across the reach, valve, door, drawer and puck tasks.
+
+Each task is registered as its own ``OpenArm-MultiTask-*`` id so it can be
+played and evaluated individually, but all five share one experiment name, one
+observation layout and one set of weights. The lift task is excluded: its
+effort-controlled finger gives it a genuinely different action space from the
+8-dimensional joint-position action the other five share.
+"""
+
+from mjlab.tasks.registry import register_mjlab_task
+
+from openarm_mjlab.tasks.multitask.env_cfgs import (
+    multitask_door_env_cfg,
+    multitask_drawer_env_cfg,
+    multitask_puck_env_cfg,
+    multitask_reach_env_cfg,
+    multitask_valve_env_cfg,
+)
+from openarm_mjlab.tasks.multitask.rl_cfg import multitask_ppo_runner_cfg
+
+for _task_id, _builder in (
+    ("OpenArm-MultiTask-Reach", multitask_reach_env_cfg),
+    ("OpenArm-MultiTask-Valve", multitask_valve_env_cfg),
+    ("OpenArm-MultiTask-Door", multitask_door_env_cfg),
+    ("OpenArm-MultiTask-Drawer", multitask_drawer_env_cfg),
+    ("OpenArm-MultiTask-Puck", multitask_puck_env_cfg),
+):
+    register_mjlab_task(
+        task_id=_task_id,
+        env_cfg=_builder(),
+        play_env_cfg=_builder(play=True),
+        rl_cfg=multitask_ppo_runner_cfg(),
+    )

--- a/src/openarm_mjlab/tasks/multitask/env_cfgs.py
+++ b/src/openarm_mjlab/tasks/multitask/env_cfgs.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MultiTask variants of the five tasks that share one policy.
+
+Each variant takes its task's own, unmodified ``*_env_cfg`` builder and
+rewrites only the observation groups: the task's object block is placed in a
+reserved slot, the remaining slots are zero-filled, and a task-identity
+one-hot is appended. Rewards, terminations and actions are untouched, so each
+task keeps exactly the behaviour it was solved with standalone.
+
+Per-task object-block widths were read off each built observation manager
+rather than assumed: reach 3 (tool_to_target), valve/door/drawer 5
+(angle + ee_to_X + contact), puck 7 (tool_to_puck + puck_to_goal +
+push_contact).
+"""
+
+from itertools import accumulate
+
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.managers.observation_manager import ObservationTermCfg
+
+from openarm_mjlab.tasks.door.door_env_cfg import openarm_door_env_cfg
+from openarm_mjlab.tasks.drawer.drawer_env_cfg import openarm_drawer_env_cfg
+from openarm_mjlab.tasks.multitask import mdp
+from openarm_mjlab.tasks.puck.puck_env_cfg import openarm_puck_env_cfg
+from openarm_mjlab.tasks.reach.reach_env_cfg import openarm_reach_env_cfg
+from openarm_mjlab.tasks.valve.valve_env_cfg import openarm_valve_env_cfg
+
+_OBJECT_WIDTH = {
+    "reach": 3,
+    "valve": 5,
+    "door": 5,
+    "drawer": 5,
+    "puck": 7,
+}
+
+# Disjoint per-task slots. Sharing one padded block across tasks put unrelated
+# quantities on the same index -- valve_angle for valve, door_angle for door,
+# drawer_pos for drawer, a Cartesian offset for reach and puck. rsl_rl keeps
+# ONE running mean/std per index pooled over every task's samples, so those
+# statistics described a mixture of unrelated signals, and an index that was a
+# structural zero for most tasks had its std collapse toward zero and amplify
+# whichever task did use it (measured: index 41 std 0.006, a 4.3 sigma
+# distortion for reach and 7.2 sigma for puck against inputs of order 1).
+#
+# Reserving a range per task makes every index carry exactly one quantity, for
+# 18 extra observation dimensions.
+_SLOT_OFFSET = dict(
+    zip(
+        mdp.TASK_NAMES,
+        accumulate((_OBJECT_WIDTH[name] for name in mdp.TASK_NAMES), initial=0),
+    )
+)
+TOTAL_OBJECT_WIDTH = sum(_OBJECT_WIDTH.values())
+
+
+def _unify(cfg: ManagerBasedRlEnvCfg, task_name: str) -> ManagerBasedRlEnvCfg:
+    """Rewrite one task's observation groups into the shared layout.
+
+    The padding is inserted immediately after the variable-width object block
+    and BEFORE ``actions``, so ``actions`` lands at the same column for every
+    task. Appending it at the end instead put ``actions`` at a different raw
+    index per task (reach 39:47, valve/door/drawer 41:49, puck 43:51), which
+    left a single normalizer statistic fitted against up to three different
+    action components; the std in that range had ballooned to 5-15 against
+    0.1-0.5 in the correctly aligned joint region, crushing the network's own
+    last-action feedback after normalization. Only the task-id one-hot goes at
+    the very end.
+    """
+    index = mdp.TASK_NAMES.index(task_name)
+    before = _SLOT_OFFSET[task_name]
+    after = TOTAL_OBJECT_WIDTH - before - _OBJECT_WIDTH[task_name]
+    for group_name in ("actor", "critic"):
+        terms = cfg.observations[group_name].terms
+        items = list(terms.items())
+        last_key, last_term = items[-1]
+        if last_key != "actions":
+            raise ValueError(
+                f"expected 'actions' to be the last pre-unification term for "
+                f"{task_name}/{group_name}, got {last_key!r}: the fixed-offset "
+                f"layout below no longer holds"
+            )
+        leading = [key for key, _ in items[:2]]
+        if leading != ["joint_pos", "joint_vel"]:
+            raise ValueError(
+                f"expected joint_pos/joint_vel to lead {task_name}/{group_name}, "
+                f"got {leading}: the object block is items[2:-1], which the "
+                f"disjoint-slot layout depends on"
+            )
+        terms.clear()
+        for key, term in items[:2]:
+            terms[key] = term
+        if before > 0:
+            terms["mt_slot_before"] = ObservationTermCfg(
+                func=mdp.zero_pad, params={"width": before}
+            )
+        for key, term in items[2:-1]:
+            terms[key] = term
+        if after > 0:
+            terms["mt_slot_after"] = ObservationTermCfg(
+                func=mdp.zero_pad, params={"width": after}
+            )
+        terms[last_key] = last_term
+        terms["mt_task_id"] = ObservationTermCfg(
+            func=mdp.task_id_onehot, params={"index": index}
+        )
+    return cfg
+
+
+def multitask_reach_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Return the reach task in the shared multi-task observation layout."""
+    return _unify(openarm_reach_env_cfg(play=play), "reach")
+
+
+def multitask_valve_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Return the valve task in the shared multi-task observation layout."""
+    return _unify(openarm_valve_env_cfg(play=play), "valve")
+
+
+def multitask_door_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Return the door task in the shared multi-task observation layout."""
+    return _unify(openarm_door_env_cfg(play=play), "door")
+
+
+def multitask_drawer_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Return the drawer task in the shared multi-task observation layout."""
+    return _unify(openarm_drawer_env_cfg(play=play), "drawer")
+
+
+def multitask_puck_env_cfg(play: bool = False) -> ManagerBasedRlEnvCfg:
+    """Return the puck task in the shared multi-task observation layout."""
+    return _unify(openarm_puck_env_cfg(play=play), "puck")

--- a/src/openarm_mjlab/tasks/multitask/mdp.py
+++ b/src/openarm_mjlab/tasks/multitask/mdp.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observation terms that make five separate tasks share one policy input.
+
+Reach, valve, door, drawer and puck already share an identical
+``joint_pos(18)`` / ``joint_vel(18)`` / ``actions(8)`` structure; only each
+task's own object-relative block differs in width (reach 3, valve/door/drawer
+5, puck 7). Padding those blocks into disjoint per-task slots and appending a
+task-identity one-hot gives every task the same observation shape, which is
+the one thing a single shared network genuinely requires. Rewards,
+terminations and actions are left untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+TASK_NAMES = ("reach", "valve", "door", "drawer", "puck")
+
+
+def task_id_onehot(env: ManagerBasedRlEnv, index: int) -> torch.Tensor:
+    """Return a constant one-hot task identity, the goal-conditioning signal."""
+    onehot = torch.zeros(env.num_envs, len(TASK_NAMES), device=env.device)
+    onehot[:, index] = 1.0
+    return onehot
+
+
+def zero_pad(env: ManagerBasedRlEnv, width: int) -> torch.Tensor:
+    """Return constant zero padding that reserves one task's observation slot."""
+    return torch.zeros(env.num_envs, width, device=env.device)

--- a/src/openarm_mjlab/tasks/multitask/mixture_env.py
+++ b/src/openarm_mjlab/tasks/multitask/mixture_env.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A vectorised environment whose every batch spans all five tasks at once.
+
+Training the tasks one at a time and varying the schedule -- visit length,
+ordering, weighting -- cannot remove catastrophic forgetting, because
+sequential fine-tuning is the structure that produces it; in every such run
+whatever trained last was the only thing left. Putting rollouts from all five
+tasks in every PPO batch removes the mechanism instead of mitigating it: the
+gradient always carries all five, so there is nothing to forget between them.
+
+This owns one ``ManagerBasedRlEnv`` per task and presents them to rsl_rl as a
+single vectorised environment. The model needs no change, because
+``MultiHeadMLPModel`` already selects its head per sample from the task
+one-hot that ``env_cfgs._unify`` puts in the observation.
+"""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.tasks.registry import load_env_cfg
+
+MULTITASK_IDS = (
+    "OpenArm-MultiTask-Reach",
+    "OpenArm-MultiTask-Valve",
+    "OpenArm-MultiTask-Door",
+    "OpenArm-MultiTask-Drawer",
+    "OpenArm-MultiTask-Puck",
+)
+
+
+class MultiTaskMixtureVecEnv:
+    """One vectorised environment whose batch spans every task at once."""
+
+    def __init__(
+        self,
+        num_envs_total: int,
+        device: str = "cuda:0",
+        task_ids: tuple[str, ...] = MULTITASK_IDS,
+        disable_corruption: bool = False,
+        weights: tuple[float, ...] | None = None,
+    ) -> None:
+        """Allocate environments across tasks, optionally unequally.
+
+        An equal split starves the hardest task. Standalone drawer needed 1024
+        envs for 3000 iterations to solve; an even five-way split of 1000 envs
+        gives it 200. ``weights`` is the mixture's equivalent of task
+        weighting, except that here every task still appears in every batch, so
+        buying one task more data costs the others throughput rather than
+        retention.
+        """
+        count = len(task_ids)
+        if weights is None:
+            counts = [num_envs_total // count] * count
+        else:
+            if len(weights) != count:
+                raise ValueError(
+                    f"expected one weight per task, got {len(weights)} for {count}"
+                )
+            total = sum(weights)
+            counts = [max(1, int(num_envs_total * w / total)) for w in weights]
+        if min(counts) <= 0:
+            raise ValueError(f"{num_envs_total} envs cannot cover {count} tasks")
+
+        self.task_ids = task_ids
+        self.counts = counts
+        self.envs: list[ManagerBasedRlEnv] = []
+        for task, n in zip(task_ids, counts):
+            cfg = load_env_cfg(task)
+            cfg.scene.num_envs = n
+            if disable_corruption and "actor" in cfg.observations:
+                cfg.observations["actor"].enable_corruption = False
+            self.envs.append(ManagerBasedRlEnv(cfg=cfg, device=device))
+
+        self.num_envs = sum(counts)
+        # Row ranges per task, since the split need not be uniform.
+        self.bounds: list[tuple[int, int]] = []
+        offset = 0
+        for n in counts:
+            self.bounds.append((offset, offset + n))
+            offset += n
+        self.device = torch.device(device)
+        # Tasks differ in episode length; each sub-env still enforces its own,
+        # this is only what the runner reports.
+        self.max_episode_length = max(e.max_episode_length for e in self.envs)
+        self.num_actions = self.envs[0].action_manager.total_action_dim
+        self.cfg = self.envs[0].cfg
+        self.unwrapped = self.envs[0]
+
+    @property
+    def episode_length_buf(self) -> torch.Tensor:
+        """Return the concatenated per-environment episode step counters."""
+        return torch.cat([e.episode_length_buf for e in self.envs])
+
+    @episode_length_buf.setter
+    def episode_length_buf(self, value: torch.Tensor) -> None:
+        for i, env in enumerate(self.envs):
+            low, high = self.bounds[i]
+            env.episode_length_buf = value[low:high]
+
+    def _pack(self, per_env_obs: list[dict]) -> TensorDict:
+        groups = per_env_obs[0].keys()
+        merged = {
+            group: torch.cat([obs[group] for obs in per_env_obs], dim=0)
+            for group in groups
+        }
+        return TensorDict(merged, batch_size=[self.num_envs])
+
+    def get_observations(self) -> TensorDict:
+        """Return the current observation for every task's environments."""
+        return self._pack([e.observation_manager.compute() for e in self.envs])
+
+    def reset(self) -> tuple[TensorDict, dict]:
+        """Reset every task's environments and return the packed observation."""
+        observations: list[dict] = []
+        extras: dict = {}
+        for env in self.envs:
+            obs, extra = env.reset()
+            observations.append(obs)
+            extras = self._merge_extras(extras, extra)
+        return self._pack(observations), extras
+
+    @staticmethod
+    def _merge_extras(acc: dict, new: dict) -> dict:
+        """Concatenate per-environment tensors and average scalar statistics."""
+        for key, value in new.items():
+            if isinstance(value, dict):
+                acc[key] = MultiTaskMixtureVecEnv._merge_extras(acc.get(key, {}), value)
+            elif torch.is_tensor(value) and value.dim() >= 1:
+                acc[key] = torch.cat([acc[key], value]) if key in acc else value
+            elif torch.is_tensor(value):
+                acc[key] = (acc[key] + value) / 2 if key in acc else value
+            else:
+                acc[key] = value
+        return acc
+
+    def step(self, actions: torch.Tensor):
+        """Step every task's environments with its slice of the action batch."""
+        observations, rewards, dones = [], [], []
+        extras: dict = {}
+        for i, env in enumerate(self.envs):
+            low, high = self.bounds[i]
+            obs, reward, terminated, truncated, extra = env.step(actions[low:high])
+            observations.append(obs)
+            rewards.append(reward)
+            dones.append((terminated | truncated).to(dtype=torch.long))
+            if not env.cfg.is_finite_horizon:
+                extra["time_outs"] = truncated
+            extras = self._merge_extras(extras, extra)
+        return (
+            self._pack(observations),
+            torch.cat(rewards),
+            torch.cat(dones),
+            extras,
+        )
+
+    def task_index_of_batch(self) -> torch.Tensor:
+        """Return which task each row of the batch belongs to."""
+        return torch.cat(
+            [
+                torch.full((n,), i, device=self.device, dtype=torch.long)
+                for i, n in enumerate(self.counts)
+            ]
+        )
+
+    def close(self) -> None:
+        """Close every task's environments."""
+        for env in self.envs:
+            env.close()

--- a/src/openarm_mjlab/tasks/multitask/multihead_model.py
+++ b/src/openarm_mjlab/tasks/multitask/multihead_model.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A shared trunk with one output head per task, selected by the task one-hot.
+
+Sequential fine-tuning across the five tasks always ended with only the
+last-trained task working. Two measurements said that was not classic
+catastrophic forgetting. The shared observation normalizer was not
+responsible: its stored sample count reaches ~2e8, so one learning iteration
+of ~24.5k samples moves the running statistics by about 0.01%, far too little
+to explain reach dropping from 100% to 0.000 within a single iteration. And
+the loss was masking rather than destruction: a 100-iteration reach revisit on
+a finished checkpoint restored reach from 0.074 to 0.953, against the ~2000
+iterations it needs from scratch, which a network that had truly destroyed the
+skill could not do.
+
+Together those point at the shared trunk still encoding all five tasks while
+the comparatively small mapping on top gets overwritten. Per-task output heads
+stop that overwriting directly, and cost far less than the Fisher-information
+machinery of EWC, for which rsl_rl exposes no hooks.
+
+Only two things are overridden on ``MLPModel``: ``get_latent`` reads the task
+one-hot from the RAW observation before normalization, and ``mlp`` is wrapped
+so the final layer becomes one head per task.
+"""
+
+from __future__ import annotations
+
+import torch
+from rsl_rl.models import MLPModel
+from torch import nn
+
+# The task one-hot occupies the final observation dims; see env_cfgs._unify,
+# which appends ``mt_task_id`` last.
+NUM_TASKS = 5
+
+# Width of each task's private hidden layer. A single Linear(128 -> 8) per task
+# is very little private capacity on top of a trunk serving five manipulation
+# behaviours, and concurrent training made the shortfall visible: with every
+# batch containing all five tasks, so interference between visits is
+# structurally impossible, skills still appeared and then vanished. That is an
+# optimisation failure in the shared trunk rather than forgetting. At 128 each
+# task gets 17,544 private parameters instead of 1,032.
+HEAD_HIDDEN = 128
+
+
+class _MultiHead(nn.Module):
+    """A shared trunk followed by one output head per task."""
+
+    def __init__(
+        self, mlp: nn.Module, num_tasks: int, owner: MultiHeadMLPModel
+    ) -> None:
+        super().__init__()
+        layers = list(mlp)
+        if not isinstance(layers[-1], nn.Linear):
+            raise TypeError(
+                f"expected the MLP to end in nn.Linear, got {type(layers[-1]).__name__}"
+            )
+        self.trunk = nn.Sequential(*layers[:-1])
+        last = layers[-1]
+        self.heads = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(last.in_features, HEAD_HIDDEN),
+                    nn.ELU(),
+                    nn.Linear(HEAD_HIDDEN, last.out_features),
+                )
+                for _ in range(num_tasks)
+            ]
+        )
+        # Plain attribute rather than a submodule, so it never enters the
+        # state dict.
+        object.__setattr__(self, "_owner", owner)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the trunk, then the head belonging to each sample's task."""
+        latent = self.trunk(x)
+        stacked = torch.stack([head(latent) for head in self.heads], dim=1)
+        index = self._owner.task_index
+        if index is None:
+            # No task one-hot seen yet, e.g. a shape-probing call: fall back to
+            # head 0 rather than guessing.
+            return stacked[:, 0]
+        index = index.to(stacked.device).clamp(0, stacked.shape[1] - 1)
+        gathered = stacked.gather(
+            1, index.view(-1, 1, 1).expand(-1, 1, stacked.shape[-1])
+        )
+        return gathered.squeeze(1)
+
+
+class MultiHeadMLPModel(MLPModel):
+    """An ``MLPModel`` whose output head is chosen by the task one-hot."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Build the base model, then replace its head with one head per task."""
+        super().__init__(*args, **kwargs)
+        self.task_index: torch.Tensor | None = None
+        self.mlp = _MultiHead(self.mlp, NUM_TASKS, self)
+
+    def get_latent(self, obs, masks=None, hidden_state=None) -> torch.Tensor:
+        """Normalize the observation, capturing the task index beforehand.
+
+        The index is read from the RAW one-hot. After normalization the one-hot
+        is no longer 0/1, and since each dimension gets its own mean and std,
+        an argmax over normalized values is not guaranteed to agree with the
+        argmax of the raw one-hot.
+        """
+        raw = torch.cat([obs[group] for group in self.obs_groups], dim=-1)
+        if raw.shape[-1] >= NUM_TASKS:
+            self.task_index = raw[..., -NUM_TASKS:].argmax(dim=-1)
+        return self.obs_normalizer(raw)

--- a/src/openarm_mjlab/tasks/multitask/multihead_model.py
+++ b/src/openarm_mjlab/tasks/multitask/multihead_model.py
@@ -33,9 +33,19 @@ machinery of EWC, for which rsl_rl exposes no hooks.
 Only two things are overridden on ``MLPModel``: ``get_latent`` reads the task
 one-hot from the RAW observation before normalization, and ``mlp`` is wrapped
 so the final layer becomes one head per task.
+
+Export needs a third. ``get_latent`` is where the head is chosen, and rsl_rl's
+JIT and ONNX wrappers do not call it -- they run ``obs_normalizer`` and then
+``mlp`` directly. A traced copy therefore has no way to read the one-hot, and
+``torch.jit.trace`` freezes whatever index the tracing input happened to
+produce, so every exported policy runs the head of the task that was traced
+regardless of the observation it is given. ``as_jit`` and ``as_onnx`` below
+return wrappers that select the head inside the graph instead.
 """
 
 from __future__ import annotations
+
+import copy
 
 import torch
 from rsl_rl.models import MLPModel
@@ -120,3 +130,79 @@ class MultiHeadMLPModel(MLPModel):
         if raw.shape[-1] >= NUM_TASKS:
             self.task_index = raw[..., -NUM_TASKS:].argmax(dim=-1)
         return self.obs_normalizer(raw)
+
+    def as_jit(self) -> nn.Module:
+        """Return a TorchScript-compatible copy that selects its own head."""
+        return _TorchMultiHeadModel(self)
+
+    def as_onnx(self, verbose: bool) -> nn.Module:
+        """Return an ONNX-compatible copy that selects its own head."""
+        return _OnnxMultiHeadModel(self, verbose)
+
+
+class _ExportMultiHead(nn.Module):
+    """Deployment copy of the model, with head selection inside the graph.
+
+    The base wrappers in rsl_rl call ``obs_normalizer`` and then ``mlp``,
+    bypassing ``get_latent`` and so bypassing the only place the task one-hot
+    is read. This does the same work on the raw observation tensor, so the
+    argmax becomes a node in the traced graph rather than a Python value
+    captured at trace time.
+    """
+
+    def __init__(self, model: MultiHeadMLPModel) -> None:
+        super().__init__()
+        self.obs_normalizer = copy.deepcopy(model.obs_normalizer)
+        multi_head = model.mlp
+        self.trunk = copy.deepcopy(multi_head.trunk)
+        self.heads = copy.deepcopy(multi_head.heads)
+        if model.distribution is not None:
+            self.deterministic_output = (
+                model.distribution.as_deterministic_output_module()
+            )
+        else:
+            self.deterministic_output = nn.Identity()
+        self.input_size = model.obs_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run deterministic inference on pre-concatenated observations."""
+        index = x[..., -NUM_TASKS:].argmax(dim=-1)
+        latent = self.trunk(self.obs_normalizer(x))
+        stacked = torch.stack([head(latent) for head in self.heads], dim=1)
+        gathered = stacked.gather(
+            1, index.view(-1, 1, 1).expand(-1, 1, stacked.shape[-1])
+        )
+        return self.deterministic_output(gathered.squeeze(1))
+
+
+class _TorchMultiHeadModel(_ExportMultiHead):
+    """Exportable multi-head model for JIT."""
+
+    @torch.jit.export
+    def reset(self) -> None:
+        """Reset recurrent export state (no-op for MLP exports)."""
+        pass
+
+
+class _OnnxMultiHeadModel(_ExportMultiHead):
+    """Exportable multi-head model for ONNX."""
+
+    is_recurrent: bool = False
+
+    def __init__(self, model: MultiHeadMLPModel, verbose: bool) -> None:
+        super().__init__(model)
+        self.verbose = verbose
+
+    def get_dummy_inputs(self) -> tuple[torch.Tensor]:
+        """Return representative dummy inputs for ONNX tracing."""
+        return (torch.zeros(1, self.input_size),)
+
+    @property
+    def input_names(self) -> list[str]:
+        """Return ONNX input tensor names."""
+        return ["obs"]
+
+    @property
+    def output_names(self) -> list[str]:
+        """Return ONNX output tensor names."""
+        return ["actions"]

--- a/src/openarm_mjlab/tasks/multitask/multihead_model.py
+++ b/src/openarm_mjlab/tasks/multitask/multihead_model.py
@@ -36,11 +36,15 @@ so the final layer becomes one head per task.
 
 Export needs a third. ``get_latent`` is where the head is chosen, and rsl_rl's
 JIT and ONNX wrappers do not call it -- they run ``obs_normalizer`` and then
-``mlp`` directly. A traced copy therefore has no way to read the one-hot, and
-``torch.jit.trace`` freezes whatever index the tracing input happened to
-produce, so every exported policy runs the head of the task that was traced
-regardless of the observation it is given. ``as_jit`` and ``as_onnx`` below
-return wrappers that select the head inside the graph instead.
+``mlp`` directly, so neither can read the one-hot at all. The two paths then
+fail differently. ``export_policy_to_jit`` runs ``torch.jit.script``, which
+cannot compile the selection and raises. ``export_policy_to_onnx`` traces
+against an all-zero dummy observation, which makes the head index a constant:
+argmax over an all-zero one-hot is head 0, so the exported policy runs reach's
+head for every task without raising anything.
+
+``as_jit`` and ``as_onnx`` below return wrappers that select the head from the
+observation inside the graph instead.
 """
 
 from __future__ import annotations
@@ -146,8 +150,11 @@ class _ExportMultiHead(nn.Module):
     The base wrappers in rsl_rl call ``obs_normalizer`` and then ``mlp``,
     bypassing ``get_latent`` and so bypassing the only place the task one-hot
     is read. This does the same work on the raw observation tensor, so the
-    argmax becomes a node in the traced graph rather than a Python value
-    captured at trace time.
+    argmax becomes a node in the exported graph rather than a Python value
+    fixed when that graph was built.
+
+    Everything here has to stay compatible with ``torch.jit.script`` as well
+    as with tracing, since the JIT and ONNX exporters use one each.
     """
 
     def __init__(self, model: MultiHeadMLPModel) -> None:
@@ -163,12 +170,21 @@ class _ExportMultiHead(nn.Module):
         else:
             self.deterministic_output = nn.Identity()
         self.input_size = model.obs_dim
+        # An instance attribute, not the module-level constant: TorchScript
+        # cannot close over a global int, and ``export_policy_to_jit`` runs
+        # ``torch.jit.script``, not ``torch.jit.trace``.
+        self.num_tasks = int(NUM_TASKS)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run deterministic inference on pre-concatenated observations."""
-        index = x[..., -NUM_TASKS:].argmax(dim=-1)
+        index = x[..., x.shape[-1] - self.num_tasks :].argmax(dim=-1)
         latent = self.trunk(self.obs_normalizer(x))
-        stacked = torch.stack([head(latent) for head in self.heads], dim=1)
+        # A plain loop rather than a comprehension: TorchScript can iterate an
+        # nn.ModuleList, but not comprehend over one.
+        outputs: list[torch.Tensor] = []
+        for head in self.heads:
+            outputs.append(head(latent))
+        stacked = torch.stack(outputs, dim=1)
         gathered = stacked.gather(
             1, index.view(-1, 1, 1).expand(-1, 1, stacked.shape[-1])
         )

--- a/src/openarm_mjlab/tasks/multitask/ppo.py
+++ b/src/openarm_mjlab/tasks/multitask/ppo.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO with per-task advantage normalization, for mixed multi-task batches."""
+
+from __future__ import annotations
+
+from tensordict import TensorDict
+
+from rsl_rl.algorithms import PPO
+
+from openarm_mjlab.tasks.multitask.multihead_model import NUM_TASKS
+
+
+class MultiTaskPPO(PPO):
+    """PPO that standardizes advantages within each task rather than globally.
+
+    Stock PPO standardizes advantages with one mean and std over the whole
+    batch. With five tasks of different reward scales in every batch, the task
+    with the largest advantages dominates and the rest are scaled into noise.
+    That was measured on the first concurrent run: reach alone learned while
+    the other four sat at exactly 0.000 for 1000 iterations, and the batch mean
+    reward, 17.05, sat right at reach's standalone value of 19.65.
+
+    Tasks are identified from the one-hot that ``env_cfgs._unify`` appends to
+    the observation, so this stays correct no matter how the mixture allocates
+    environments -- including the deliberately unequal splits that give a
+    harder task more of them.
+    """
+
+    def compute_returns(self, obs: TensorDict) -> None:
+        """Compute returns, then standardize advantages within each task."""
+        # Suppress the base class's single global pass; the per-task pass below
+        # replaces it. Restored immediately so minibatch behaviour is unchanged.
+        previous = self.normalize_advantage_per_mini_batch
+        self.normalize_advantage_per_mini_batch = True
+        try:
+            super().compute_returns(obs)
+        finally:
+            self.normalize_advantage_per_mini_batch = previous
+
+        task_index = self._task_index(obs)
+        if task_index is None:
+            # No task one-hot present: fall back to the standard global pass so
+            # this class stays usable on a single-task environment.
+            advantages = self.storage.advantages
+            self.storage.advantages = (advantages - advantages.mean()) / (
+                advantages.std() + 1e-8
+            )
+            return
+
+        advantages = self.storage.advantages
+        for task in range(NUM_TASKS):
+            rows = task_index == task
+            if not bool(rows.any()):
+                continue
+            block = advantages[:, rows]
+            advantages[:, rows] = (block - block.mean()) / (block.std() + 1e-8)
+
+    @staticmethod
+    def _task_index(obs: TensorDict):
+        """Return the per-environment task index, or None if unavailable."""
+        actor_obs = obs.get("actor", None)
+        if actor_obs is None or actor_obs.shape[-1] < NUM_TASKS:
+            return None
+        return actor_obs[..., -NUM_TASKS:].argmax(dim=-1)

--- a/src/openarm_mjlab/tasks/multitask/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/multitask/rl_cfg.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner configuration shared by all five MultiTask registrations."""
+
+from mjlab.rl import (
+    RslRlModelCfg,
+    RslRlOnPolicyRunnerCfg,
+    RslRlPpoAlgorithmCfg,
+)
+
+MULTITASK_EXPERIMENT_NAME = "openarm_multitask"
+
+
+def multitask_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the runner config for the shared multi-task policy.
+
+    Architecture and hyperparameters match the single-task configurations;
+    what makes this one shared policy is that all five registrations use the
+    same experiment name, the actor carries one output head per task, and the
+    algorithm standardizes advantages per task.
+    """
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            class_name=(
+                "openarm_mjlab.tasks.multitask.multihead_model.MultiHeadMLPModel"
+            ),
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        # The critic stays single-headed: it is never deployed, and a value
+        # function shared across tasks acts as a regulariser.
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            class_name="openarm_mjlab.tasks.multitask.ppo.MultiTaskPPO",
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name=MULTITASK_EXPERIMENT_NAME,
+        save_interval=50,
+        num_steps_per_env=24,
+        max_iterations=3000,
+    )

--- a/src/openarm_mjlab/tasks/puck/__init__.py
+++ b/src/openarm_mjlab/tasks/puck/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenArm move-puck task, privileged and vision variants."""
+
+from mjlab.tasks.manipulation.rl import ManipulationOnPolicyRunner
+from mjlab.tasks.registry import register_mjlab_task
+
+from .puck_env_cfg import openarm_puck_env_cfg
+from .rl_cfg import openarm_puck_ppo_runner_cfg, openarm_puck_vision_ppo_runner_cfg
+
+register_mjlab_task(
+    task_id="OpenArm-Puck",
+    env_cfg=openarm_puck_env_cfg(),
+    play_env_cfg=openarm_puck_env_cfg(play=True),
+    rl_cfg=openarm_puck_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)
+
+# Same task/rewards/terminations/events -- only the actor's observations
+# change (privileged puck-position terms swapped for a fixed overhead
+# depth camera). Separate task_id so the privileged checkpoint is never
+# touched.
+register_mjlab_task(
+    task_id="OpenArm-Puck-Vision",
+    env_cfg=openarm_puck_env_cfg(vision=True),
+    play_env_cfg=openarm_puck_env_cfg(play=True, vision=True),
+    rl_cfg=openarm_puck_vision_ppo_runner_cfg(),
+    runner_cls=ManipulationOnPolicyRunner,
+)

--- a/src/openarm_mjlab/tasks/puck/mdp.py
+++ b/src/openarm_mjlab/tasks/puck/mdp.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Move-puck (pushing) MDP terms.
+
+Pushing needs no grasp, so the anti-cheat surface is smaller than the
+drawer/valve tasks: the one exploit to close is FLICKING (smack the puck
+and let it coast to the goal). The approach-rate reward is contact-gated
+and capped (coasting earns nothing), success requires the puck SETTLED at
+the goal, and puck overspeed is penalized.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from mjlab.entity import Entity
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.utils.lab_api.math import quat_apply, quat_inv
+
+from ...common_mdp import fingers_on_handle
+from ...robot_bimanual import GRASP_LOCAL_OFFSET
+
+if TYPE_CHECKING:
+    from mjlab.envs import ManagerBasedRlEnv
+
+# Goal disc, local to the env origin.
+GOAL_LOCAL = (0.33, -0.30, 0.422)
+SUCCESS_DIST = 0.025  # m, planar.
+SETTLED_SPEED = 0.05  # m/s
+MAX_PUSH_SPEED = 0.25  # m/s, puck speed cap for the rate reward.
+
+
+def _goal_w(env) -> torch.Tensor:
+    # mjlab batches each env as its OWN world: physics coordinates are
+    # raw; env_origins is only a viewer layout grid. Do NOT add origins.
+    goal = torch.tensor(GOAL_LOCAL, device=env.device)
+    return goal.expand(env.num_envs, 3)
+
+
+def puck_pos_w(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the puck's world position."""
+    puck: Entity = env.scene[asset_cfg.name]
+    return puck.data.root_link_pos_w
+
+
+def puck_speed(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the puck's planar speed."""
+    puck: Entity = env.scene[asset_cfg.name]
+    return torch.linalg.norm(puck.data.root_link_vel_w[:, :2], dim=-1)
+
+
+def puck_goal_dist(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return the planar distance from the puck to the goal center."""
+    d = puck_pos_w(env, asset_cfg)[:, :2] - _goal_w(env)[:, :2]
+    return torch.linalg.norm(d, dim=-1)
+
+
+def puck_to_goal_obs(
+    env: ManagerBasedRlEnv,
+    asset_cfg: SceneEntityCfg,
+    robot_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the puck to the goal, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    vec_w = _goal_w(env) - puck_pos_w(env, asset_cfg)
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def tool_to_puck_obs(
+    env: ManagerBasedRlEnv,
+    robot_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return the vector from the finger-cage center to the puck, base frame."""
+    robot: Entity = env.scene[robot_cfg.name]
+    ee_pos_w = robot.data.site_pos_w[:, robot_cfg.site_ids].squeeze(1)
+    ee_quat_w = robot.data.site_quat_w[:, robot_cfg.site_ids].squeeze(1)
+    offset = torch.tensor(GRASP_LOCAL_OFFSET, device=ee_pos_w.device).expand_as(
+        ee_pos_w
+    )
+    tool_w = ee_pos_w + quat_apply(ee_quat_w, offset)
+    vec_w = puck_pos_w(env, asset_cfg) - tool_w
+    return quat_apply(quat_inv(robot.data.root_link_quat_w), vec_w)
+
+
+def reach_puck_reward(
+    env: ManagerBasedRlEnv,
+    std: float,
+    robot_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a Gaussian-kernel reward on tool-to-puck distance."""
+    d2 = torch.sum(torch.square(tool_to_puck_obs(env, robot_cfg, asset_cfg)), dim=-1)
+    return torch.exp(-d2 / std**2)
+
+
+def push_contact_obs(env: ManagerBasedRlEnv, sensor_name: str) -> torch.Tensor:
+    """Return the observation wrapper for puck contact."""
+    return fingers_on_handle(env, sensor_name).float().unsqueeze(-1)
+
+
+def push_rate_reward(
+    env: ManagerBasedRlEnv,
+    sensor_name: str,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return a contact-gated, capped rate of approach to the goal (0..1).
+
+    Coasting after a flick earns nothing (contact gate); speed above the
+    cap earns no more than the cap. New-progress-only against the
+    episode's best distance so push-pull cycling cannot farm income.
+    """
+    dist = puck_goal_dist(env, asset_cfg)
+    if not hasattr(env, "_puck_min_dist"):
+        env._puck_min_dist = dist.clone()
+    new = torch.clamp(env._puck_min_dist - dist, min=0.0)
+    env._puck_min_dist.copy_(torch.minimum(env._puck_min_dist, dist))
+    capped = torch.clamp(new / env.step_dt, 0.0, MAX_PUSH_SPEED) / MAX_PUSH_SPEED
+    return capped * fingers_on_handle(env, sensor_name).float()
+
+
+def at_goal_reward(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return a reward for settling at the goal: close AND slow.
+
+    A 1.2x band, not the exact success band: outside it the hold pays
+    nothing, so parking just inside the success band without truly
+    settling has no income.
+    """
+    close = puck_goal_dist(env, asset_cfg) < 1.2 * SUCCESS_DIST
+    slow = puck_speed(env, asset_cfg) < SETTLED_SPEED
+    return (close & slow).float()
+
+
+def goal_fine_reward(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return a dense centering gradient in the 0-10cm band.
+
+    The rate reward saturates near the goal disc, so nothing else pulls
+    the puck the last few centimeters without this term.
+    """
+    d = puck_goal_dist(env, asset_cfg)
+    return torch.exp(-((d / 0.05) ** 2))
+
+
+def puck_overspeed_penalty(
+    env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Return a penalty for puck speed beyond ``MAX_PUSH_SPEED``."""
+    return torch.clamp(puck_speed(env, asset_cfg) - MAX_PUSH_SPEED, min=0.0)
+
+
+def push_success_bonus(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Fire exactly once, on the ``puck_at_goal`` termination step."""
+    return env.termination_manager.get_term("puck_at_goal").float()
+
+
+def puck_at_goal(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return success: the puck settled inside the goal disc."""
+    close = puck_goal_dist(env, asset_cfg) < SUCCESS_DIST
+    slow = puck_speed(env, asset_cfg) < SETTLED_SPEED
+    return close & slow
+
+
+def puck_fell(env: ManagerBasedRlEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Return early termination: the puck was knocked off the table (top z=0.40)."""
+    return puck_pos_w(env, asset_cfg)[:, 2] < 0.30
+
+
+def puck_fell_penalty(env: ManagerBasedRlEnv) -> torch.Tensor:
+    """Return a penalty on the ``puck_fell`` termination step.
+
+    The direct negative counterpart to :func:`push_success_bonus`: without
+    it, a fall is only punished implicitly (by forfeiting future dense
+    income), which is too weak a deterrent once a policy drifts toward a
+    faster, more aggressive push -- ending in a fall should be punished as
+    directly as ending in success is rewarded.
+    """
+    return env.termination_manager.get_term("puck_fell").float()
+
+
+def reset_puck_uniform(
+    env: ManagerBasedRlEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    xy_range: float = 0.03,
+) -> None:
+    """Reset the puck to its default pose plus xy jitter.
+
+    Free-body resets must start from the default state (which already
+    contains the env origin for attached free bodies) and add jitter on
+    top, rather than adding origins a second time.
+    """
+    puck: Entity = env.scene[asset_cfg.name]
+    default = puck.data.default_root_state
+    assert default is not None
+    state = default[env_ids].clone()
+    n = len(env_ids)
+    state[:, 0] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 1] += (torch.rand(n, device=env.device) * 2 - 1) * xy_range
+    state[:, 7:] = 0.0
+    puck.write_root_state_to_sim(state, env_ids=env_ids)
+    # Seed the rate buffer from the WRITTEN positions: derived kinematics
+    # are stale inside reset events.
+    goal = torch.tensor(GOAL_LOCAL, device=env.device)
+    d = torch.linalg.norm(state[:, :2] - goal[:2], dim=-1)
+    if not hasattr(env, "_puck_min_dist"):
+        env._puck_min_dist = puck_goal_dist(env, asset_cfg).clone()
+    env._puck_min_dist[env_ids] = d

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -1,0 +1,358 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment configuration for the OpenArm move-puck task.
+
+A 70x70x44mm puck is pushed into a goal disc and left there. Pushing
+needs no grasp: fully feasible contact-only.
+"""
+
+import mujoco
+from mjlab.entity import EntityCfg
+from mjlab.envs import ManagerBasedRlEnvCfg
+from mjlab.envs.mdp import dr
+from mjlab.envs.mdp.actions import JointPositionActionCfg
+from mjlab.managers.action_manager import ActionTermCfg
+from mjlab.managers.event_manager import EventTermCfg
+from mjlab.managers.observation_manager import ObservationGroupCfg, ObservationTermCfg
+from mjlab.managers.reward_manager import RewardTermCfg
+from mjlab.managers.scene_entity_config import SceneEntityCfg
+from mjlab.managers.termination_manager import TerminationTermCfg
+from mjlab.scene import SceneCfg
+from mjlab.sensor import CameraSensorCfg, ContactMatch, ContactSensorCfg
+from mjlab.sim import MujocoCfg, SimulationCfg
+from mjlab.tasks.manipulation import mdp as manipulation_mdp
+from mjlab.tasks.velocity import mdp as base_mdp
+from mjlab.terrains import TerrainEntityCfg
+from mjlab.utils.noise import UniformNoiseCfg as Unoise
+from mjlab.viewer import ViewerConfig
+
+from ...actions import HoldDefaultPositionActionCfg
+from ...robot_bimanual import (
+    BIMANUAL_ACTION_SCALE,
+    EE_SITE_RIGHT,
+    get_bimanual_robot_cfg,
+)
+from . import mdp as puck_mdp
+
+PUCK_START = (0.20, -0.14, 0.422)
+
+
+def get_table_spec() -> mujoco.MjSpec:
+    """Build the static table slab + goal disc marker spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "puck_table"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="table")
+    body.add_geom(
+        name="table_top",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.41, 0.55, 0.04),
+        pos=(0.47, 0.0, 0.36),
+        rgba=(0.82, 0.71, 0.55, 1.0),
+        friction=(1.0, 0.005, 0.0001),
+    )
+    body.add_site(
+        name="goal_site",
+        type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+        size=(0.05, 0.001, 0),
+        pos=(puck_mdp.GOAL_LOCAL[0], puck_mdp.GOAL_LOCAL[1], 0.401),
+        rgba=(0.2, 0.8, 0.3, 0.4),
+    )
+    return spec
+
+
+def get_puck_spec() -> mujoco.MjSpec:
+    """Build the free-body puck fixture spec."""
+    spec = mujoco.MjSpec()
+    spec.modelname = "puck"
+    spec.compiler.degree = False
+    body = spec.worldbody.add_body(name="puck")
+    body.add_freejoint(name="puck_free")
+    body.add_geom(
+        name="puck_geom",
+        type=mujoco.mjtGeom.mjGEOM_BOX,
+        size=(0.035, 0.035, 0.022),
+        mass=0.2,
+        friction=(0.4, 0.01, 0.01),
+        rgba=(0.85, 0.4, 0.1, 1.0),
+    )
+    return spec
+
+
+ROBOT_EE_CFG = SceneEntityCfg("robot", site_names=(EE_SITE_RIGHT,))
+PUCK_CFG = SceneEntityCfg("puck")
+
+FINGER_PUCK_SENSOR = ContactSensorCfg(
+    name="finger_puck_contact",
+    primary=ContactMatch(
+        mode="subtree",
+        pattern="openarm_right_ee_base_link",
+        entity="robot",
+    ),
+    secondary=ContactMatch(mode="geom", pattern="puck_geom", entity="puck"),
+    fields=("found",),
+    reduce="none",
+    num_slots=1,
+)
+
+# World-fixed overhead depth camera. A MuJoCo camera looks down its own
+# -Z by convention, so the identity quaternion here means straight down.
+PUCK_TABLECAM_POS = (0.26, -0.18, 1.15)
+PUCK_TABLECAM_QUAT = (1.0, 0.0, 0.0, 0.0)
+PUCK_TABLECAM_FOVY = 60.0
+
+
+def openarm_puck_env_cfg(
+    play: bool = False, vision: bool = False
+) -> ManagerBasedRlEnvCfg:
+    """Build the OpenArm move-puck environment config.
+
+    With ``vision=True``, the actor loses the privileged puck-position
+    observation terms and instead relies on a fixed overhead depth
+    camera; the critic (discarded at deployment) keeps full privileged
+    state and also gets the camera, the same asymmetric actor-critic
+    pattern mjlab's own vision reference task uses.
+    """
+    actor_terms = {
+        "joint_pos": ObservationTermCfg(
+            func=base_mdp.joint_pos_rel, noise=Unoise(n_min=-0.01, n_max=0.01)
+        ),
+        "joint_vel": ObservationTermCfg(
+            func=base_mdp.joint_vel_rel, noise=Unoise(n_min=-1.5, n_max=1.5)
+        ),
+        "tool_to_puck": ObservationTermCfg(
+            func=puck_mdp.tool_to_puck_obs,
+            params={"robot_cfg": ROBOT_EE_CFG, "asset_cfg": PUCK_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "puck_to_goal": ObservationTermCfg(
+            func=puck_mdp.puck_to_goal_obs,
+            params={"asset_cfg": PUCK_CFG, "robot_cfg": ROBOT_EE_CFG},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        ),
+        "push_contact": ObservationTermCfg(
+            func=puck_mdp.push_contact_obs,
+            params={"sensor_name": "finger_puck_contact"},
+        ),
+        "actions": ObservationTermCfg(func=base_mdp.last_action),
+    }
+    observations = {
+        "actor": ObservationGroupCfg(actor_terms, enable_corruption=True),
+        "critic": ObservationGroupCfg(dict(actor_terms), enable_corruption=False),
+    }
+    actions: dict[str, ActionTermCfg] = {
+        "joint_pos": JointPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_right_.*",),
+            scale=BIMANUAL_ACTION_SCALE,
+            use_default_offset=True,
+        ),
+        "left_hold": HoldDefaultPositionActionCfg(
+            entity_name="robot",
+            actuator_names=("openarm_left_.*",),
+            scale=1.0,
+            use_default_offset=True,
+        ),
+    }
+    events = {
+        "reset_robot_joints": EventTermCfg(
+            func=base_mdp.reset_joints_by_offset,
+            mode="reset",
+            params={
+                "position_range": (-0.05, 0.05),
+                "velocity_range": (0.0, 0.0),
+                "asset_cfg": SceneEntityCfg("robot", joint_names=(".*",)),
+            },
+        ),
+        "reset_puck": EventTermCfg(
+            func=puck_mdp.reset_puck_uniform,
+            mode="reset",
+            params={"asset_cfg": PUCK_CFG, "xy_range": 0.03},
+        ),
+        # Domain randomization, same verified pattern as the other tasks.
+        # Puck is a free body (no joint dynamics axis, like reach) --
+        # friction, mass, and arm gains only.
+        "dr_puck_friction": EventTermCfg(
+            mode="startup",
+            func=dr.geom_friction,
+            params={
+                "asset_cfg": SceneEntityCfg("puck", geom_names=("puck_geom",)),
+                "operation": "scale",
+                "distribution": "uniform",
+                "axes": [0],
+                "ranges": (0.6, 1.4),
+            },
+        ),
+        "dr_puck_mass": EventTermCfg(
+            mode="startup",
+            func=dr.pseudo_inertia,
+            params={
+                "asset_cfg": SceneEntityCfg("puck", body_names=("puck",)),
+                "alpha_range": (-0.1, 0.1),
+            },
+        ),
+        "dr_arm_gains": EventTermCfg(
+            mode="startup",
+            func=dr.pd_gains,
+            params={
+                "asset_cfg": SceneEntityCfg("robot"),
+                "kp_range": (0.85, 1.15),
+                "kd_range": (0.85, 1.15),
+                "operation": "scale",
+            },
+        ),
+    }
+    rewards = {
+        "reach_puck": RewardTermCfg(
+            func=puck_mdp.reach_puck_reward,
+            weight=1.0,
+            params={"std": 0.2, "robot_cfg": ROBOT_EE_CFG, "asset_cfg": PUCK_CFG},
+        ),
+        "push_rate": RewardTermCfg(
+            func=puck_mdp.push_rate_reward,
+            weight=3.0,
+            params={"sensor_name": "finger_puck_contact", "asset_cfg": PUCK_CFG},
+        ),
+        "goal_fine": RewardTermCfg(
+            func=puck_mdp.goal_fine_reward, weight=2.0, params={"asset_cfg": PUCK_CFG}
+        ),
+        "at_goal": RewardTermCfg(
+            func=puck_mdp.at_goal_reward, weight=2.0, params={"asset_cfg": PUCK_CFG}
+        ),
+        "success": RewardTermCfg(
+            func=puck_mdp.push_success_bonus, weight=800.0, params={}
+        ),
+        "puck_overspeed": RewardTermCfg(
+            func=puck_mdp.puck_overspeed_penalty,
+            weight=-2.0,
+            params={"asset_cfg": PUCK_CFG},
+        ),
+        # Direct negative counterpart to "success" (half its magnitude):
+        # without this, a fall was only punished implicitly by losing
+        # future dense income, too weak a deterrent once training drifts
+        # toward a faster, more aggressive push.
+        "puck_fell": RewardTermCfg(
+            func=puck_mdp.puck_fell_penalty, weight=-400.0, params={}
+        ),
+        "action_rate_l2": RewardTermCfg(func=base_mdp.action_rate_l2, weight=-0.01),
+        "joint_vel_hinge": RewardTermCfg(
+            func=manipulation_mdp.joint_velocity_hinge_penalty,
+            weight=-0.05,
+            params={
+                "max_vel": 1.0,
+                "asset_cfg": SceneEntityCfg("robot", joint_names=("openarm_right_.*",)),
+            },
+        ),
+        "joint_pos_limits": RewardTermCfg(
+            func=base_mdp.joint_pos_limits,
+            weight=-10.0,
+            params={
+                "asset_cfg": SceneEntityCfg(
+                    "robot", joint_names=("openarm_(left|right)_joint[1-7]",)
+                )
+            },
+        ),
+    }
+    terminations = {
+        "time_out": TerminationTermCfg(func=base_mdp.time_out, time_out=True),
+        "puck_at_goal": TerminationTermCfg(
+            func=puck_mdp.puck_at_goal, params={"asset_cfg": PUCK_CFG}
+        ),
+        "puck_fell": TerminationTermCfg(
+            func=puck_mdp.puck_fell, params={"asset_cfg": PUCK_CFG}
+        ),
+    }
+    cfg = ManagerBasedRlEnvCfg(
+        scene=SceneCfg(
+            terrain=TerrainEntityCfg(terrain_type="plane"),
+            entities={
+                "robot": get_bimanual_robot_cfg(),
+                "table": EntityCfg(spec_fn=get_table_spec),
+                "puck": EntityCfg(
+                    spec_fn=get_puck_spec,
+                    init_state=EntityCfg.InitialStateCfg(pos=PUCK_START),
+                ),
+            },
+            num_envs=1,
+            env_spacing=2.5,
+            sensors=(FINGER_PUCK_SENSOR,),
+        ),
+        observations=observations,
+        actions=actions,
+        commands={},
+        events=events,
+        rewards=rewards,
+        terminations=terminations,
+        curriculum={},
+        viewer=ViewerConfig(
+            origin_type=ViewerConfig.OriginType.ASSET_BODY,
+            entity_name="robot",
+            body_name="openarm_right_base_link",
+            distance=1.6,
+            elevation=-20.0,
+            azimuth=220.0,
+        ),
+        sim=SimulationCfg(
+            nconmax=150,
+            njmax=1000,
+            mujoco=MujocoCfg(
+                timestep=0.005,
+                iterations=10,
+                ls_iterations=20,
+                impratio=10,
+                cone="elliptic",
+            ),
+        ),
+        decimation=4,
+        episode_length_s=8.0,
+    )
+    if vision:
+        # Depth-only (matches mjlab's own vision reference task's
+        # simplest variant): avoids RGB/lighting domain-randomization
+        # complexity for a first vision attempt. The camera group is
+        # separate from "actor"/"critic" so rl_cfg's obs_groups controls
+        # which policy sees it.
+        cam_cfg = CameraSensorCfg(
+            name="tablecam",
+            pos=PUCK_TABLECAM_POS,
+            quat=PUCK_TABLECAM_QUAT,
+            fovy=PUCK_TABLECAM_FOVY,
+            width=64,
+            height=64,
+            data_types=("depth",),
+            use_shadows=False,
+            use_textures=True,
+        )
+        cfg.scene.sensors = (cfg.scene.sensors or ()) + (cam_cfg,)
+        cfg.observations["camera"] = ObservationGroupCfg(
+            terms={
+                "tablecam_depth": ObservationTermCfg(
+                    func=manipulation_mdp.camera_depth,
+                    params={"sensor_name": "tablecam", "cutoff_distance": 1.0},
+                ),
+            },
+            enable_corruption=False,
+            concatenate_terms=True,
+        )
+        # The puck's goal is a fixed constant (not resampled per
+        # episode), so no separate goal-conditioning term is needed --
+        # the network can learn it directly.
+        actor_obs = cfg.observations["actor"]
+        actor_obs.terms.pop("tool_to_puck")
+        actor_obs.terms.pop("puck_to_goal")
+    if play:
+        cfg.episode_length_s = int(1e9)
+        cfg.observations["actor"].enable_corruption = False
+    return cfg

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -87,6 +87,20 @@ def get_puck_spec() -> mujoco.MjSpec:
         mass=0.2,
         friction=(0.4, 0.01, 0.01),
         rgba=(0.85, 0.4, 0.1, 1.0),
+        # Without a priority this friction never applied anywhere, so the
+        # puck was declared slippery and never was. MuJoCo takes the
+        # higher-priority geom's contact parameters and mixes only when
+        # priorities are equal, and that mix is an elementwise MAX. The
+        # right-arm finger geoms are priority=1, so they governed the push
+        # contact at mu=1.0; the table is priority=0 like the puck was, so
+        # that pair mixed to max(0.4, 1.0) = 1.0 as well. dr_puck_friction
+        # was randomizing a number MuJoCo read on neither pair. Outranking
+        # both makes the declared 0.4 govern (measured: 0.4 at the finger
+        # and 0.4 at the table). condim=4 and the fingers' own solref keep
+        # the finger contact model as it was, so only the friction changes.
+        priority=2,
+        condim=4,
+        solref=(0.005, 1.0),
     )
     return spec
 

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -304,6 +304,7 @@ def openarm_puck_env_cfg(
         viewer=ViewerConfig(
             origin_type=ViewerConfig.OriginType.WORLD,
             lookat=(0.28, -0.22, 0.50),
+            distance=1.6,
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/puck_env_cfg.py
@@ -296,11 +296,14 @@ def openarm_puck_env_cfg(
         rewards=rewards,
         terminations=terminations,
         curriculum={},
+        # A fixed WORLD camera rather than an ASSET_BODY tracking one:
+        # MuJoCo tracking cameras follow the tracked body's subtree COM
+        # (here the whole right arm), so offscreen-rendered videos sway
+        # with every arm motion. mjlab's interactive viewer works around
+        # that, so the artifact only shows up in recorded video.
         viewer=ViewerConfig(
-            origin_type=ViewerConfig.OriginType.ASSET_BODY,
-            entity_name="robot",
-            body_name="openarm_right_base_link",
-            distance=1.6,
+            origin_type=ViewerConfig.OriginType.WORLD,
+            lookat=(0.28, -0.22, 0.50),
             elevation=-20.0,
             azimuth=220.0,
         ),

--- a/src/openarm_mjlab/tasks/puck/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/rl_cfg.py
@@ -52,7 +52,7 @@ def openarm_puck_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
         experiment_name="openarm_puck",
         save_interval=100,
         num_steps_per_env=24,
-        max_iterations=2_000,
+        max_iterations=3_000,
     )
 
 

--- a/src/openarm_mjlab/tasks/puck/rl_cfg.py
+++ b/src/openarm_mjlab/tasks/puck/rl_cfg.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO runner config for the OpenArm move-puck task, privileged and vision variants."""
+
+from mjlab.rl import RslRlModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
+
+
+def openarm_puck_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the privileged-state puck task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(512, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_puck",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=2_000,
+    )
+
+
+# Same small CNN + spatial-softmax architecture mjlab's own vision
+# reference task uses: proven, not reinvented.
+_VISION_CNN_CFG = {
+    "output_channels": [16, 32],
+    "kernel_size": [5, 3],
+    "stride": [2, 2],
+    "padding": "zeros",
+    "activation": "elu",
+    "max_pool": False,
+    "global_pool": "none",
+    "spatial_softmax": True,
+    "spatial_softmax_temperature": 1.0,
+}
+_VISION_MODEL_CLS = "mjlab.rl.spatial_softmax:SpatialSoftmaxCNNModel"
+
+
+def openarm_puck_vision_ppo_runner_cfg() -> RslRlOnPolicyRunnerCfg:
+    """Return the depth-camera-only puck task's PPO runner config."""
+    return RslRlOnPolicyRunnerCfg(
+        actor=RslRlModelCfg(
+            hidden_dims=(256, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            cnn_cfg=_VISION_CNN_CFG,
+            class_name=_VISION_MODEL_CLS,
+            distribution_cfg={
+                "class_name": "GaussianDistribution",
+                "init_std": 1.0,
+                "std_type": "scalar",
+            },
+        ),
+        critic=RslRlModelCfg(
+            hidden_dims=(256, 256, 128),
+            activation="elu",
+            obs_normalization=True,
+            cnn_cfg=_VISION_CNN_CFG,
+            class_name=_VISION_MODEL_CLS,
+        ),
+        algorithm=RslRlPpoAlgorithmCfg(
+            value_loss_coef=1.0,
+            use_clipped_value_loss=True,
+            clip_param=0.2,
+            entropy_coef=0.01,
+            num_learning_epochs=5,
+            num_mini_batches=4,
+            learning_rate=1.0e-3,
+            schedule="adaptive",
+            gamma=0.99,
+            lam=0.95,
+            desired_kl=0.01,
+            max_grad_norm=1.0,
+        ),
+        experiment_name="openarm_puck_vision",
+        save_interval=100,
+        num_steps_per_env=24,
+        max_iterations=3_000,
+        obs_groups={
+            "actor": ("actor", "camera"),
+            "critic": ("critic", "camera"),
+        },
+    )

--- a/tests/test_multitask_env.py
+++ b/tests/test_multitask_env.py
@@ -153,3 +153,87 @@ def test_config_points_at_the_multitask_classes():
         module_path, _, attr = path.rpartition(".")
         resolved = getattr(importlib.import_module(module_path), attr)
         assert resolved is expected, path
+
+
+def _build_model(head_hidden: int = 0):
+    """A MultiHeadMLPModel with deliberately distinct heads.
+
+    The heads a fresh model gets are near-identical, so a wrong head would
+    still produce nearly the right numbers and the test would pass on broken
+    code. Offsetting each head makes picking the wrong one unmistakable.
+    """
+    from tensordict import TensorDict
+
+    from openarm_mjlab.tasks.multitask.multihead_model import MultiHeadMLPModel
+
+    obs_dim = OBS_DIM
+    obs = TensorDict(
+        {"actor": torch.zeros(1, obs_dim), "critic": torch.zeros(1, obs_dim)},
+        batch_size=[1],
+    )
+    groups = {"actor": ["actor"], "critic": ["critic"]}
+    model = MultiHeadMLPModel(
+        obs,
+        groups,
+        "actor",
+        8,
+        (64, 64),
+        "elu",
+        True,
+        {"class_name": "GaussianDistribution", "init_std": 1.0, "std_type": "scalar"},
+    )
+    model.eval()
+    for offset, head in enumerate(model.mlp.heads):
+        for param in head.parameters():
+            param.data.add_(float(offset))
+    return model
+
+
+def test_exported_policy_selects_the_head_the_one_hot_asks_for():
+    """The head must be chosen inside the exported graph, not at trace time.
+
+    rsl_rl's export wrappers skip ``get_latent``, which is the only place the
+    task one-hot is read. Without an override, ``torch.jit.trace`` bakes in the
+    index its tracing input produced -- an all-zero observation, so head 0 --
+    and every exported policy runs reach's head whatever task it is given.
+    """
+    from tensordict import TensorDict
+
+    model = _build_model()
+    exported = torch.jit.trace(model.as_jit(), torch.zeros(1, OBS_DIM))
+
+    torch.manual_seed(0)
+    core = torch.randn(4, OBS_DIM - NUM_TASKS)
+    for index, name in enumerate(mdp.TASK_NAMES):
+        raw = torch.cat([core, torch.zeros(4, NUM_TASKS)], dim=-1)
+        raw[:, OBS_DIM - NUM_TASKS + index] = 1.0
+        obs = TensorDict({"actor": raw, "critic": raw}, batch_size=[4])
+        with torch.no_grad():
+            eager = model(obs)
+            traced = exported(raw)
+        assert torch.allclose(eager, traced, atol=1e-5), (
+            f"{name}: exported policy disagrees with the eager model by "
+            f"{(eager - traced).abs().max().item():.4f} -- it is running a "
+            "different task's head"
+        )
+
+
+def test_onnx_export_wrapper_selects_the_head_too():
+    """The ONNX path needs the same treatment as the JIT path."""
+    from tensordict import TensorDict
+
+    model = _build_model()
+    onnx_model = model.as_onnx(verbose=False)
+    (dummy,) = onnx_model.get_dummy_inputs()
+    assert dummy.shape == (1, OBS_DIM)
+    assert onnx_model.input_names == ["obs"]
+    assert onnx_model.output_names == ["actions"]
+
+    torch.manual_seed(0)
+    core = torch.randn(4, OBS_DIM - NUM_TASKS)
+    for index, name in enumerate(mdp.TASK_NAMES):
+        raw = torch.cat([core, torch.zeros(4, NUM_TASKS)], dim=-1)
+        raw[:, OBS_DIM - NUM_TASKS + index] = 1.0
+        obs = TensorDict({"actor": raw, "critic": raw}, batch_size=[4])
+        with torch.no_grad():
+            assert torch.allclose(model(obs), onnx_model(raw), atol=1e-5), name

--- a/tests/test_multitask_env.py
+++ b/tests/test_multitask_env.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the shared multi-task observation layout.
+
+Note: building an env compiles mujoco-warp CPU kernels; the first run can take
+a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+from openarm_mjlab.tasks.multitask import mdp
+from openarm_mjlab.tasks.multitask.env_cfgs import (
+    TOTAL_OBJECT_WIDTH,
+    _SLOT_OFFSET,
+)
+from openarm_mjlab.tasks.multitask.multihead_model import NUM_TASKS
+
+TASK_IDS = {
+    "reach": "OpenArm-MultiTask-Reach",
+    "valve": "OpenArm-MultiTask-Valve",
+    "door": "OpenArm-MultiTask-Door",
+    "drawer": "OpenArm-MultiTask-Drawer",
+    "puck": "OpenArm-MultiTask-Puck",
+}
+
+# joint_pos(18) + joint_vel(18) + the shared object region + actions(8) + the
+# task one-hot. Every task pads to the same total, which is the point.
+OBS_DIM = 18 + 18 + TOTAL_OBJECT_WIDTH + 8 + NUM_TASKS
+
+
+def test_every_multitask_id_is_registered():
+    registered = list_tasks()
+    for task_id in TASK_IDS.values():
+        assert task_id in registered
+
+
+def test_slots_are_disjoint_and_cover_the_region():
+    """Each task owns a distinct range, and together they tile the region."""
+    covered: set[int] = set()
+    for name in mdp.TASK_NAMES:
+        start = _SLOT_OFFSET[name]
+        width = {"reach": 3, "valve": 5, "door": 5, "drawer": 5, "puck": 7}[name]
+        span = set(range(start, start + width))
+        assert not (span & covered), f"{name}'s slot overlaps another task's"
+        covered |= span
+    assert covered == set(range(TOTAL_OBJECT_WIDTH))
+
+
+@pytest.fixture(scope="module")
+def envs():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    built = {}
+    for name, task_id in TASK_IDS.items():
+        cfg = load_env_cfg(task_id)
+        cfg.scene.num_envs = 2
+        built[name] = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield built
+    for env in built.values():
+        env.close()
+
+
+def test_all_tasks_share_one_observation_shape(envs):
+    """A single network is only usable if every task presents one shape."""
+    for name, env in envs.items():
+        obs, _ = env.reset()
+        assert obs["actor"].shape == (2, OBS_DIM), name
+        assert obs["critic"].shape == (2, OBS_DIM), name
+        assert env.action_manager.total_action_dim == 8, name
+
+
+def test_task_one_hot_is_last_and_identifies_the_task(envs):
+    """The final dims must be a clean one-hot; the model reads them raw."""
+    for name, env in envs.items():
+        obs, _ = env.reset()
+        onehot = obs["actor"][:, -NUM_TASKS:]
+        assert torch.equal(onehot.sum(dim=-1), torch.ones(2)), name
+        expected = mdp.TASK_NAMES.index(name)
+        assert torch.equal(
+            onehot.argmax(dim=-1), torch.full((2,), expected, dtype=torch.long)
+        ), name
+
+
+def test_unused_slots_are_zero(envs):
+    """A task must not write outside the slot it owns."""
+    start_of_region = 18 + 18
+    for name, env in envs.items():
+        obs, _ = env.reset()
+        region = obs["actor"][:, start_of_region : start_of_region + TOTAL_OBJECT_WIDTH]
+        own_start = _SLOT_OFFSET[name]
+        own_width = {"reach": 3, "valve": 5, "door": 5, "drawer": 5, "puck": 7}[name]
+        before = region[:, :own_start]
+        after = region[:, own_start + own_width :]
+        assert torch.count_nonzero(before) == 0, f"{name} wrote before its slot"
+        assert torch.count_nonzero(after) == 0, f"{name} wrote after its slot"
+
+
+def test_actions_land_at_the_same_column_for_every_task(envs):
+    """The layout bug this guards against put 'actions' at a different index."""
+    actions_start = 18 + 18 + TOTAL_OBJECT_WIDTH
+    for name, env in envs.items():
+        obs, _ = env.reset()
+        terms = env.observation_manager.cfg["actor"].terms
+        keys = list(terms.keys())
+        assert keys[-1] == "mt_task_id", name
+        assert keys[-2] == "actions", name
+        assert obs["actor"].shape[1] == actions_start + 8 + NUM_TASKS, name
+
+
+def test_env_steps_with_finite_signals(envs):
+    for name, env in envs.items():
+        env.reset()
+        for _ in range(5):
+            action = torch.zeros(2, env.action_manager.total_action_dim)
+            obs, rew, terminated, truncated, _ = env.step(action)
+            assert torch.isfinite(obs["actor"]).all(), name
+            assert torch.isfinite(rew).all(), name
+
+
+def test_config_points_at_the_multitask_classes():
+    """Guard the silent-fallback risk: a bad path would quietly use stock PPO.
+
+    ``class_name`` is resolved by string at runtime, so a typo or a moved class
+    degrades to the default single-head model and global advantage
+    normalization without raising anything.
+    """
+    import importlib
+
+    from openarm_mjlab.tasks.multitask.multihead_model import MultiHeadMLPModel
+    from openarm_mjlab.tasks.multitask.ppo import MultiTaskPPO
+    from openarm_mjlab.tasks.multitask.rl_cfg import multitask_ppo_runner_cfg
+
+    cfg = multitask_ppo_runner_cfg()
+    for path, expected in (
+        (cfg.actor.class_name, MultiHeadMLPModel),
+        (cfg.algorithm.class_name, MultiTaskPPO),
+    ):
+        module_path, _, attr = path.rpartition(".")
+        resolved = getattr(importlib.import_module(module_path), attr)
+        assert resolved is expected, path

--- a/tests/test_multitask_env.py
+++ b/tests/test_multitask_env.py
@@ -189,39 +189,53 @@ def _build_model(head_hidden: int = 0):
     return model
 
 
-def test_exported_policy_selects_the_head_the_one_hot_asks_for():
-    """The head must be chosen inside the exported graph, not at trace time.
-
-    rsl_rl's export wrappers skip ``get_latent``, which is the only place the
-    task one-hot is read. Without an override, ``torch.jit.trace`` bakes in the
-    index its tracing input produced -- an all-zero observation, so head 0 --
-    and every exported policy runs reach's head whatever task it is given.
-    """
+def _one_hot_obs(index: int, core: torch.Tensor):
+    """A raw observation batch tagged for one task."""
     from tensordict import TensorDict
 
+    raw = torch.cat([core, torch.zeros(len(core), NUM_TASKS)], dim=-1)
+    raw[:, OBS_DIM - NUM_TASKS + index] = 1.0
+    return raw, TensorDict({"actor": raw, "critic": raw}, batch_size=[len(core)])
+
+
+def test_jit_export_selects_the_head_the_one_hot_asks_for():
+    """The head must be chosen inside the exported graph.
+
+    rsl_rl's export wrappers skip ``get_latent``, which is the only place the
+    task one-hot is read, so a model that leaves head selection there cannot
+    be exported correctly. This uses ``torch.jit.script``, which is what
+    ``export_policy_to_jit`` calls -- on the unfixed model it fails outright
+    with ``Module '_MultiHead' has no attribute '_owner'``.
+    """
     model = _build_model()
-    exported = torch.jit.trace(model.as_jit(), torch.zeros(1, OBS_DIM))
+    exported = torch.jit.script(model.as_jit())
 
     torch.manual_seed(0)
     core = torch.randn(4, OBS_DIM - NUM_TASKS)
     for index, name in enumerate(mdp.TASK_NAMES):
-        raw = torch.cat([core, torch.zeros(4, NUM_TASKS)], dim=-1)
-        raw[:, OBS_DIM - NUM_TASKS + index] = 1.0
-        obs = TensorDict({"actor": raw, "critic": raw}, batch_size=[4])
+        raw, obs = _one_hot_obs(index, core)
         with torch.no_grad():
             eager = model(obs)
-            traced = exported(raw)
-        assert torch.allclose(eager, traced, atol=1e-5), (
+            scripted = exported(raw)
+        assert torch.allclose(eager, scripted, atol=1e-5), (
             f"{name}: exported policy disagrees with the eager model by "
-            f"{(eager - traced).abs().max().item():.4f} -- it is running a "
+            f"{(eager - scripted).abs().max().item():.4f} -- it is running a "
             "different task's head"
         )
 
 
 def test_onnx_export_wrapper_selects_the_head_too():
-    """The ONNX path needs the same treatment as the JIT path."""
-    from tensordict import TensorDict
+    """The ONNX path needs the same treatment, and fails more quietly.
 
+    ``export_policy_to_onnx`` traces with an all-zero dummy observation. On
+    the unfixed model the head index is a Python value read at trace time, so
+    ``argmax`` of an all-zero one-hot bakes in head 0 and every exported
+    policy runs reach's head whatever task it is given -- with nothing raised.
+
+    Checked at the wrapper level rather than through a real ONNX round trip
+    because that would need onnxruntime, which this package does not depend
+    on. The wrapper is where the selection lives, so it is what regresses.
+    """
     model = _build_model()
     onnx_model = model.as_onnx(verbose=False)
     (dummy,) = onnx_model.get_dummy_inputs()
@@ -232,8 +246,6 @@ def test_onnx_export_wrapper_selects_the_head_too():
     torch.manual_seed(0)
     core = torch.randn(4, OBS_DIM - NUM_TASKS)
     for index, name in enumerate(mdp.TASK_NAMES):
-        raw = torch.cat([core, torch.zeros(4, NUM_TASKS)], dim=-1)
-        raw[:, OBS_DIM - NUM_TASKS + index] = 1.0
-        obs = TensorDict({"actor": raw, "critic": raw}, batch_size=[4])
+        raw, obs = _one_hot_obs(index, core)
         with torch.no_grad():
             assert torch.allclose(model(obs), onnx_model(raw), atol=1e-5), name

--- a/tests/test_puck_env.py
+++ b/tests/test_puck_env.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the OpenArm-Puck and OpenArm-Puck-Vision environments.
+
+Note: building the env compiles mujoco-warp CPU kernels; the first run can
+take a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+
+# joint_pos/joint_vel report ALL 18 bimanual joints (both arms), regardless
+# of which arm this task actually actuates.
+OBS_DIM = 18 + 18 + 3 + 3 + 1 + 8  # joint_pos, joint_vel, tool_to_puck,
+# puck_to_goal, push_contact, actions
+VISION_ACTOR_OBS_DIM = OBS_DIM - 3 - 3  # privileged puck-position terms dropped.
+
+
+def test_tasks_are_registered():
+    assert "OpenArm-Puck" in list_tasks()
+    assert "OpenArm-Puck-Vision" in list_tasks()
+
+
+@pytest.fixture(scope="module")
+def env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Puck")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+@pytest.fixture(scope="module")
+def vision_env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg("OpenArm-Puck-Vision")
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_action_and_observation_dims(env):
+    assert env.action_manager.total_action_dim == 8
+    obs, _ = env.reset()
+    assert obs["actor"].shape == (2, OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+
+
+def test_env_steps_with_finite_signals(env):
+    env.reset()
+    for _ in range(10):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()
+        assert terminated.shape == (2,)
+        assert truncated.shape == (2,)
+
+
+def test_reset_puck_spawns_within_xy_range(env):
+    """`reset_puck_uniform` must spawn every env within its declared jitter."""
+    from openarm_mjlab.tasks.puck.puck_env_cfg import PUCK_CFG, PUCK_START
+    from openarm_mjlab.tasks.puck.mdp import puck_pos_w
+
+    env.reset()
+    pos = puck_pos_w(env, PUCK_CFG)
+    start = torch.tensor(PUCK_START[:2])
+    assert (pos[:, :2] - start).abs().max() <= 0.03 + 1e-6
+
+
+def test_vision_actor_drops_privileged_puck_state(vision_env):
+    """The vision actor must lose the privileged terms while the critic keeps them."""
+    obs, _ = vision_env.reset()
+    assert obs["actor"].shape == (2, VISION_ACTOR_OBS_DIM)
+    assert obs["critic"].shape == (2, OBS_DIM)
+    assert obs["camera"].shape == (2, 1, 64, 64)
+
+
+def test_vision_env_steps_with_finite_signals(vision_env):
+    vision_env.reset()
+    for _ in range(5):
+        action = torch.zeros(2, vision_env.action_manager.total_action_dim)
+        obs, rew, terminated, truncated, _ = vision_env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(obs["camera"]).all()
+        assert torch.isfinite(rew).all()
+
+
+def test_left_arm_stays_at_default_under_zero_action(env):
+    """The parked left arm must hold its default pose, not drift to qpos 0."""
+    env.reset()
+    action = torch.zeros(2, env.action_manager.total_action_dim)
+    for _ in range(20):
+        env.step(action)
+    robot = env.scene["robot"]
+    left_j4 = robot.find_joints("openarm_left_joint4")[0][0]
+    # Home pose has joint4 at 1.5708 rad; qpos 0 would mean the hold failed.
+    assert torch.allclose(
+        robot.data.joint_pos[:, left_j4], torch.tensor(1.5708), atol=0.05
+    )


### PR DESCRIPTION
One policy, one set of weights, trained on reach, valve, door, drawer and puck at once. Each task keeps its own rewards, terminations and actions; only observations are unified, into disjoint per-task slots plus a task-identity one-hot. Three changes carry it, none of which works alone: reserved observation slots so a shared normalizer never pools unrelated quantities, a mixture environment putting all five tasks in every PPO batch, and per-task output heads over a shared trunk with advantages standardized within each task. Registers `OpenArm-MultiTask-{Reach,Valve,Door,Drawer,Puck}` and an `openarm-mjlab-multitask-train` entry point.

**Results:** 256 held-out episodes per task, scored on each task's own termination term, over three seeds  reach 1.000, valve 0.996, puck 0.991, door 0.607, drawer 0.003.The valve is turned by pressing the lever with one jaw rather than grasping it,
