### PR TITLE
Add procedural task families and a policy exporter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires-python = ">=3.11"
 dependencies = [
   "openarm-mujoco",
   "mjlab>=1.5.0",
+  "onnxruntime>=1.20",
 ]
 
 [project.urls]
@@ -32,6 +33,7 @@ Issues = "https://github.com/enactic/openarm_mjlab/issues"
 Repository = "https://github.com/enactic/openarm_mjlab"
 
 [project.scripts]
+openarm-mjlab-export-policy = "openarm_mjlab.deploy.export:main"
 openarm-mjlab-play = "openarm_mjlab.play:main"
 openarm-mjlab-train = "openarm_mjlab.train:main"
 

--- a/src/openarm_mjlab/deploy/__init__.py
+++ b/src/openarm_mjlab/deploy/__init__.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenArm task registrations. Importing this package registers all tasks."""
+"""Run a trained policy outside mjlab.
 
-from . import door  # noqa: F401
-from . import drawer  # noqa: F401
-from . import families  # noqa: F401
-from . import pick_place  # noqa: F401
-from . import reach  # noqa: F401
-from . import valve  # noqa: F401
+Exports a policy to ONNX together with the contract a deployment target needs
+to use it -- action scale and offset, actuator order, decimation, solver
+settings and joint limits -- and provides a plain-MuJoCo runner that consumes
+both. Nothing here imports mujoco-warp or requires a GPU at inference.
+"""

--- a/src/openarm_mjlab/deploy/export.py
+++ b/src/openarm_mjlab/deploy/export.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export a trained policy and its scene for use outside mjlab.
+
+Writes three things next to each other:
+
+* ``policy.onnx`` / ``policy.pt`` -- the actor, with the observation
+  normaliser folded in.
+* ``policy_meta.json`` -- the contract needed to drive it: action scale and
+  offset, actuator order, decimation, solver settings, default joint positions
+  and soft joint limits. A deployment target cannot import mjlab to discover
+  these, and hardcoding them in a runner is an easy way to be quietly wrong.
+* ``scene/`` -- the compiled MJCF together with every mesh it references, so it
+  loads with plain ``mujoco.MjModel.from_xml_path`` on a machine that has
+  neither mjlab nor the original asset tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+from dataclasses import asdict
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.rl import MjlabOnPolicyRunner, RslRlVecEnvWrapper
+from mjlab.scripts.export_scene import ExportSceneCfg, export_scene
+from mjlab.tasks.registry import load_env_cfg, load_rl_cfg
+
+
+def _to_numpy(value) -> np.ndarray:
+    return value.detach().cpu().numpy() if torch.is_tensor(value) else np.asarray(value)
+
+
+def openarm_mujoco_cell_xml(openarm_v2) -> str:
+    """Return the packaged cell XML path, whatever the package version calls it."""
+    for attr in ("openarm_cell_xml", "cell_xml", "CELL_XML"):
+        value = getattr(openarm_v2, attr, None)
+        if value is None:
+            continue
+        return value() if callable(value) else value
+    raise AttributeError("openarm_mujoco.v2 exposes no cell XML accessor")
+
+
+def _merge_duplicate_default_classes(xml_text: str) -> tuple[str, int]:
+    """Merge sibling ``<default>`` blocks that share a class name.
+
+    mjlab's scene exporter can emit two ``<default class="robot/main">``
+    siblings for this robot -- one carrying the pedestal classes, one the motor
+    classes. MuJoCo rejects a repeated class name, so the exported scene will
+    not load at all without this. Merging keeps every child of both blocks,
+    which is what a single correctly-emitted block would have contained.
+    Verified equivalent against the in-mjlab compiled model.
+    """
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(xml_text)
+    merged = 0
+
+    def collapse(node: ET.Element) -> None:
+        """Splice a <default> child that repeats its parent's class name."""
+        nonlocal merged
+        changed = True
+        while changed:
+            changed = False
+            for child in list(node):
+                if child.tag != "default":
+                    continue
+                same_as_parent = (
+                    node.tag == "default"
+                    and child.get("class") is not None
+                    and child.get("class") == node.get("class")
+                )
+                if same_as_parent:
+                    index = list(node).index(child)
+                    node.remove(child)
+                    for offset, grandchild in enumerate(list(child)):
+                        node.insert(index + offset, grandchild)
+                    for key, value in child.attrib.items():
+                        node.attrib.setdefault(key, value)
+                    merged += 1
+                    changed = True
+                    break
+        for child in node:
+            collapse(child)
+
+    collapse(root)
+    # a sibling repeat would also be rejected; fold those too
+    for parent in root.iter():
+        seen: dict[str, ET.Element] = {}
+        for child in list(parent):
+            if child.tag != "default" or child.get("class") is None:
+                continue
+            name = child.get("class")
+            if name in seen:
+                for grandchild in list(child):
+                    seen[name].append(grandchild)
+                parent.remove(child)
+                merged += 1
+            else:
+                seen[name] = child
+
+    if merged == 0:
+        return xml_text, 0
+    return ET.tostring(root, encoding="unicode"), merged
+
+
+def export_scene_self_contained(task: str, out_dir: Path) -> int:
+    """Export the compiled scene and copy every mesh it references.
+
+    mjlab's exporter writes the XML but not its meshes, and the mesh root is
+    wherever the task's robot config points -- an absolute path on the machine
+    that trained the policy. Copying them makes the directory portable.
+    """
+    export_scene(ExportSceneCfg(target=task, output_dir=str(out_dir), zip=False))
+    xml_path = out_dir / "scene.xml"
+    text = xml_path.read_text()
+    text, merged = _merge_duplicate_default_classes(text)
+    if merged:
+        xml_path.write_text(text)
+        print(f"merged {merged} duplicate <default> class block(s) so the scene loads")
+    meshdir_match = re.search(r'meshdir="([^"]*)"', text)
+    meshdir = meshdir_match.group(1) if meshdir_match else "assets"
+    refs = sorted(set(re.findall(r'file="([^"]+)"', text)))
+    if not refs:
+        return 0
+
+    # Resolve the mesh root through the openarm-mujoco package rather than any
+    # absolute path, so the export works on a machine that only has the
+    # declared dependencies.
+    import openarm_mujoco.v2 as openarm_v2
+
+    cell_xml = Path(openarm_mujoco_cell_xml(openarm_v2))
+    candidates = [
+        cell_xml.parent / "assets",
+        cell_xml.parent.parent / "assets",
+        Path(str(meshdir)),
+    ]
+    root = next((c for c in candidates if (c / refs[0]).exists()), None)
+    if root is None:
+        raise FileNotFoundError(
+            f"could not locate the mesh root for {refs[0]!r}; tried "
+            f"{[str(c) for c in candidates]}"
+        )
+
+    copied = 0
+    for rel in refs:
+        dst = out_dir / meshdir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if not dst.exists():
+            shutil.copy2(root / rel, dst)
+            copied += 1
+        material = (root / rel).with_suffix(".mtl")
+        if material.exists() and not dst.with_suffix(".mtl").exists():
+            shutil.copy2(material, dst.with_suffix(".mtl"))
+            copied += 1
+    return copied
+
+
+def export(task: str, checkpoint: str, out: str, device: str = "cpu") -> None:
+    """Export the policy, its contract, and a self-contained scene."""
+    out_dir = Path(out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = load_env_cfg(task)
+    cfg.scene.num_envs = 1
+    env = ManagerBasedRlEnv(cfg=cfg, device=device)
+    agent_cfg = load_rl_cfg(task)
+    wrapped = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+    runner = MjlabOnPolicyRunner(wrapped, asdict(agent_cfg), device=device)
+    runner.load(checkpoint, load_cfg={"actor": True}, strict=True, map_location=device)
+    runner.export_policy_to_onnx(str(out_dir), "policy.onnx")
+    runner.export_policy_to_jit(str(out_dir), "policy.pt")
+
+    obs, _ = wrapped.reset()
+    action_term = env.action_manager.get_term("joint_pos")
+    robot = env.scene["robot"]
+    meta = {
+        "task": task,
+        "obs_dim": int(obs["actor"].shape[-1]),
+        "action_dim": int(env.action_manager.total_action_dim),
+        "actuator_order": [f"robot/{n}" for n in action_term.target_names],
+        "action_scale": _to_numpy(action_term._scale).ravel().tolist(),
+        "action_offset": _to_numpy(action_term._offset)[0].tolist(),
+        "decimation": int(cfg.decimation),
+        "timestep": float(cfg.sim.mujoco.timestep),
+        "episode_steps": int(
+            cfg.episode_length_s / (cfg.decimation * cfg.sim.mujoco.timestep)
+        ),
+        "default_joint_pos": _to_numpy(robot.data.default_joint_pos)[0].tolist(),
+        "soft_joint_pos_limits": _to_numpy(robot.data.soft_joint_pos_limits)[
+            0
+        ].tolist(),
+        "robot_joint_names": list(robot.joint_names),
+        "sim": {
+            "integrator": str(cfg.sim.mujoco.integrator),
+            "cone": str(cfg.sim.mujoco.cone),
+            "solver": str(cfg.sim.mujoco.solver),
+            "impratio": float(cfg.sim.mujoco.impratio),
+            "iterations": int(cfg.sim.mujoco.iterations),
+            "tolerance": float(cfg.sim.mujoco.tolerance),
+            "ls_iterations": int(cfg.sim.mujoco.ls_iterations),
+            "ls_tolerance": float(cfg.sim.mujoco.ls_tolerance),
+            "gravity": list(cfg.sim.mujoco.gravity),
+        },
+    }
+    (out_dir / "policy_meta.json").write_text(json.dumps(meta, indent=2))
+    env.close()
+
+    copied = export_scene_self_contained(task, out_dir / "scene")
+    model = mujoco.MjModel.from_xml_path(str(out_dir / "scene" / "scene.xml"))
+    print(
+        f"policy      {out_dir}/policy.onnx  ({meta['obs_dim']} obs, {meta['action_dim']} act)"
+    )
+    print(f"contract    {out_dir}/policy_meta.json")
+    print(f"scene       {out_dir}/scene/scene.xml  ({copied} mesh files copied)")
+    print(f"loads standalone: nq={model.nq} nv={model.nv} ngeom={model.ngeom}")
+
+
+def main() -> None:
+    """Parse arguments and export one policy."""
+    parser = argparse.ArgumentParser(
+        prog="openarm-mjlab-export-policy", description=__doc__.split("\n")[0]
+    )
+    parser.add_argument("task", help="registered task id")
+    parser.add_argument("checkpoint", help="path to a trained model_*.pt")
+    parser.add_argument("out", help="output directory")
+    parser.add_argument("--device", default="cpu")
+    args = parser.parse_args()
+    export(args.task, args.checkpoint, args.out, args.device)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openarm_mjlab/deploy/export.py
+++ b/src/openarm_mjlab/deploy/export.py
@@ -25,6 +25,11 @@ Writes three things next to each other:
 * ``scene/`` -- the compiled MJCF together with every mesh it references, so it
   loads with plain ``mujoco.MjModel.from_xml_path`` on a machine that has
   neither mjlab nor the original asset tree.
+
+Both policy files are read back and checked against the policy still in
+memory before the export is reported as done. An exporter that can write a
+file which does not match what was trained is the worst kind to have, because
+the next place that surfaces is on hardware.
 """
 
 from __future__ import annotations
@@ -176,6 +181,82 @@ def export_scene_self_contained(task: str, out_dir: Path) -> int:
     return copied
 
 
+def verify_exported_policy(
+    expected: np.ndarray,
+    observations: np.ndarray,
+    out_dir: Path,
+    jit_atol: float = 1e-5,
+    onnx_atol: float = 1e-3,
+) -> dict[str, float]:
+    """Check the two written files reproduce the policy they came from.
+
+    ``expected`` holds the actions the in-memory policy produced for
+    ``observations``, one row each. Both files are loaded from disk exactly as
+    a deployment would load them and run on the same inputs.
+
+    The observations must come from a rollout rather than from zeros. A
+    zero observation is what the ONNX exporter traces with, so it is the one
+    input a mis-exported policy is most likely to get right, and checking only
+    that would pass on a policy that is wrong everywhere else.
+
+    ONNX gets a looser tolerance than TorchScript because it re-associates
+    float arithmetic; TorchScript runs the same kernels and should be exact.
+
+    Returns the worst difference seen for each file. Raises if either is over
+    tolerance -- an artifact that does not match is not a usable one.
+    """
+    import onnxruntime as ort
+
+    jit_policy = torch.jit.load(str(out_dir / "policy.pt"))
+    jit_policy.eval()
+    session = ort.InferenceSession(
+        str(out_dir / "policy.onnx"), providers=["CPUExecutionProvider"]
+    )
+
+    with torch.no_grad():
+        jit_out = jit_policy(torch.from_numpy(observations)).numpy()
+    # The graph is exported with a fixed batch dimension of one, so ONNX has
+    # to be fed a row at a time.
+    onnx_out = np.concatenate(
+        [session.run(None, {"obs": row[None]})[0] for row in observations]
+    )
+
+    deltas = {
+        "policy.pt": float(np.abs(expected - jit_out).max()),
+        "policy.onnx": float(np.abs(expected - onnx_out).max()),
+    }
+    for name, atol in (("policy.pt", jit_atol), ("policy.onnx", onnx_atol)):
+        if not deltas[name] <= atol:
+            raise RuntimeError(
+                f"{name} does not reproduce the trained policy: actions differ "
+                f"by up to {deltas[name]:.4g} over {len(observations)} "
+                f"observations, tolerance {atol:g}. The exported file is not "
+                f"the policy that was loaded; do not deploy it."
+            )
+    return deltas
+
+
+def _rollout_for_verification(runner, wrapped, device: str, steps: int = 8):
+    """Actions and observations from a short rollout of the loaded policy."""
+    policy = runner.get_inference_policy(device=device)
+    obs, _ = wrapped.reset()
+    observations, actions = [], []
+    with torch.no_grad():
+        for _ in range(steps):
+            observations.append(
+                torch.cat([obs[group] for group in policy.obs_groups], dim=-1)
+                .detach()
+                .cpu()
+            )
+            action = policy(obs)
+            actions.append(action.detach().cpu())
+            obs, _, _, _ = wrapped.step(action)
+    return (
+        torch.cat(actions).numpy().astype(np.float32),
+        torch.cat(observations).numpy().astype(np.float32),
+    )
+
+
 def export(task: str, checkpoint: str, out: str, device: str = "cpu") -> None:
     """Export the policy, its contract, and a self-contained scene."""
     out_dir = Path(out)
@@ -224,12 +305,20 @@ def export(task: str, checkpoint: str, out: str, device: str = "cpu") -> None:
         },
     }
     (out_dir / "policy_meta.json").write_text(json.dumps(meta, indent=2))
+
+    expected, observations = _rollout_for_verification(runner, wrapped, device)
+    deltas = verify_exported_policy(expected, observations, out_dir)
     env.close()
 
     copied = export_scene_self_contained(task, out_dir / "scene")
     model = mujoco.MjModel.from_xml_path(str(out_dir / "scene" / "scene.xml"))
     print(
         f"policy      {out_dir}/policy.onnx  ({meta['obs_dim']} obs, {meta['action_dim']} act)"
+    )
+    print(
+        f"verified    matches the loaded policy over {len(observations)} "
+        f"observations (policy.pt {deltas['policy.pt']:.2e}, "
+        f"policy.onnx {deltas['policy.onnx']:.2e})"
     )
     print(f"contract    {out_dir}/policy_meta.json")
     print(f"scene       {out_dir}/scene/scene.xml  ({copied} mesh files copied)")

--- a/src/openarm_mjlab/deploy/observation.py
+++ b/src/openarm_mjlab/deploy/observation.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rebuild the door task's observation vector using ONLY plain MuJoCo.
+
+No mjlab, no mujoco-warp. This is what a deployment target has to do, and it is
+the part most likely to be subtly wrong -- so verify_obs_parity.py checks it
+element-by-element against mjlab at identical states before any transfer number
+is trusted.
+
+Layout (49 dims), from the door task's actor observation group:
+  joint_pos(18)  robot qpos - default qpos
+  joint_vel(18)  robot qvel  (default qvel is zero)
+  door_angle(1)  hinge qpos - default
+  ee_to_handle(3) base-frame vector, cage centre -> handle site
+  handle_contact(1) 1.0 if either fingertip touches the handle geom
+  actions(8)     previous raw action
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+
+GRASP_LOCAL_OFFSET = np.array([0.0, 0.0, -0.135])
+
+
+def _quat_apply(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Rotate v by quaternion q (w, x, y, z), matching mjlab's convention."""
+    w, x, y, z = q
+    u = np.array([x, y, z])
+    return (
+        2.0 * np.dot(u, v) * u + (w * w - np.dot(u, u)) * v + 2.0 * w * np.cross(u, v)
+    )
+
+
+def _quat_inv(q: np.ndarray) -> np.ndarray:
+    return np.array([q[0], -q[1], -q[2], -q[3]])
+
+
+class PlainObsBuilder:
+    """Resolves every index once, then rebuilds the observation each step."""
+
+    def __init__(self, model: mujoco.MjModel):
+        """Resolve joint, site, body and sensor indices once from the model."""
+        self.m = model
+
+        def name(obj_type, index):
+            return mujoco.mj_id2name(model, obj_type, index) or ""
+
+        # Robot joints, in model order, excluding the door hinge.
+        self.robot_qpos_adr, self.robot_dof_adr, self.robot_joints = [], [], []
+        for j in range(model.njnt):
+            n = name(mujoco.mjtObj.mjOBJ_JOINT, j)
+            if n.startswith("robot/"):
+                self.robot_joints.append(n)
+                self.robot_qpos_adr.append(model.jnt_qposadr[j])
+                self.robot_dof_adr.append(model.jnt_dofadr[j])
+        self.door_joint = [
+            j
+            for j in range(model.njnt)
+            if name(mujoco.mjtObj.mjOBJ_JOINT, j).endswith("door_hinge")
+        ][0]
+        self.door_qpos_adr = model.jnt_qposadr[self.door_joint]
+
+        self.ee_site = [
+            s
+            for s in range(model.nsite)
+            if name(mujoco.mjtObj.mjOBJ_SITE, s).endswith("right_ee_control_point")
+        ][0]
+        self.handle_site = [
+            s
+            for s in range(model.nsite)
+            if name(mujoco.mjtObj.mjOBJ_SITE, s).endswith("handle_site")
+        ][0]
+        self.base_body = [
+            b
+            for b in range(model.nbody)
+            if name(mujoco.mjtObj.mjOBJ_BODY, b).endswith("robot/openarm_body")
+        ]
+        if not self.base_body:
+            # fall back to the robot's root body
+            self.base_body = [
+                b
+                for b in range(model.nbody)
+                if name(mujoco.mjtObj.mjOBJ_BODY, b).startswith("robot/")
+            ][:1]
+        self.base_body = self.base_body[0]
+
+        self.contact_sensors = [
+            s
+            for s in range(model.nsensor)
+            if "finger_grip_contact" in (name(mujoco.mjtObj.mjOBJ_SENSOR, s))
+        ]
+        self.sensor_adr = [model.sensor_adr[s] for s in self.contact_sensors]
+
+        # Default pose comes from the exported keyframe.
+        key = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_KEY, "init_state")
+        self.default_qpos = np.array(model.key_qpos[key])
+        self.default_ctrl = np.array(model.key_ctrl[key])
+
+    def build(self, data: mujoco.MjData, last_action: np.ndarray) -> np.ndarray:
+        """Return the 49-dim observation for the current state."""
+        jp = np.array([data.qpos[a] for a in self.robot_qpos_adr])
+        jp0 = np.array([self.default_qpos[a] for a in self.robot_qpos_adr])
+        jv = np.array([data.qvel[a] for a in self.robot_dof_adr])
+        door = np.array(
+            [data.qpos[self.door_qpos_adr] - self.default_qpos[self.door_qpos_adr]]
+        )
+
+        ee_pos = np.array(data.site_xpos[self.ee_site])
+        ee_mat = np.array(data.site_xmat[self.ee_site]).reshape(3, 3)
+        ee_quat = np.empty(4)
+        mujoco.mju_mat2Quat(ee_quat, ee_mat.flatten())
+        tool = ee_pos + _quat_apply(ee_quat, GRASP_LOCAL_OFFSET)
+        handle = np.array(data.site_xpos[self.handle_site])
+        vec_w = handle - tool
+        base_quat = np.array(data.xquat[self.base_body])
+        ee_to_handle = _quat_apply(_quat_inv(base_quat), vec_w)
+
+        found = 0.0
+        for adr in self.sensor_adr:
+            if data.sensordata[adr] > 0:
+                found = 1.0
+                break
+        return np.concatenate(
+            [jp - jp0, jv, door, ee_to_handle, [found], last_action]
+        ).astype(np.float32)

--- a/src/openarm_mjlab/deploy/runner.py
+++ b/src/openarm_mjlab/deploy/runner.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run an exported policy in PLAIN MuJoCo -- no mjlab, no mujoco-warp.
+
+This is the deployment-shaped path: load an MJCF, load an ONNX policy, rebuild
+the observation, step the CPU physics. The success criterion is replicated from
+the task's own termination term, including its stateful bookkeeping:
+
+  swing_gained  >= 1.0 rad, measured from the episode's start angle
+  gained-under-contact >= 0.85 * target  (accrued only while a pad touches)
+  |hinge rate|  <  1.0 rad/s
+  a fingertip is touching the handle at that instant
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import onnxruntime as ort
+
+TARGET_SWING = 1.0
+MAX_SWING_RATE = 1.0
+HONEST_FRAC = 0.85
+
+
+class PlainRunner:
+    """Drives an exported ONNX policy against a plain-MuJoCo model."""
+
+    @staticmethod
+    def apply_sim_options(m: mujoco.MjModel, sim_cfg) -> None:
+        """Copy mjlab's solver configuration onto a plain MuJoCo model.
+
+        The exported MJCF carries NO <option> block, so a plain load silently
+        uses MuJoCo's defaults -- Euler instead of implicitfast, a pyramidal
+        friction cone instead of elliptic, impratio 1 instead of 10. Measured:
+        leaving them at defaults produced a 20.3-point "sim-to-sim gap" that
+        was really just two different physics configurations.
+        """
+        m.opt.timestep = sim_cfg.timestep
+        m.opt.impratio = sim_cfg.impratio
+        m.opt.iterations = sim_cfg.iterations
+        m.opt.tolerance = sim_cfg.tolerance
+        m.opt.ls_iterations = sim_cfg.ls_iterations
+        m.opt.ls_tolerance = sim_cfg.ls_tolerance
+        m.opt.gravity[:] = sim_cfg.gravity
+        m.opt.integrator = {
+            "euler": mujoco.mjtIntegrator.mjINT_EULER,
+            "rk4": mujoco.mjtIntegrator.mjINT_RK4,
+            "implicit": mujoco.mjtIntegrator.mjINT_IMPLICIT,
+            "implicitfast": mujoco.mjtIntegrator.mjINT_IMPLICITFAST,
+        }[str(sim_cfg.integrator)]
+        m.opt.cone = {
+            "pyramidal": mujoco.mjtCone.mjCONE_PYRAMIDAL,
+            "elliptic": mujoco.mjtCone.mjCONE_ELLIPTIC,
+        }[str(sim_cfg.cone)]
+        m.opt.solver = {
+            "pgs": mujoco.mjtSolver.mjSOL_PGS,
+            "cg": mujoco.mjtSolver.mjSOL_CG,
+            "newton": mujoco.mjtSolver.mjSOL_NEWTON,
+        }[str(sim_cfg.solver)]
+
+    def __init__(
+        self, xml: str, onnx_path: str, builder, decimation: int = 4, sim_cfg=None
+    ):
+        """Load the model and the ONNX policy, and resolve the actuator order."""
+        self.m = mujoco.MjModel.from_xml_path(xml)
+        if sim_cfg is not None:
+            self.apply_sim_options(self.m, sim_cfg)
+        self.d = mujoco.MjData(self.m)
+        self.b = builder
+        self.decimation = decimation
+        self.dt = self.m.opt.timestep * decimation
+        self.sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+        self.in_name = self.sess.get_inputs()[0].name
+
+        def name(obj_type, index):
+            return mujoco.mj_id2name(self.m, obj_type, index) or ""
+
+        # the 8 actuators the policy drives, in the action term's order
+        order = [f"robot/openarm_right_joint{i}" for i in range(1, 8)]
+        order.append("robot/openarm_right_finger_joint1")
+        self.act_ids = []
+        for want in order:
+            hits = [
+                a
+                for a in range(self.m.nu)
+                if name(mujoco.mjtObj.mjOBJ_ACTUATOR, a) == want
+            ]
+            if not hits:
+                raise KeyError(f"actuator not found in the exported scene: {want}")
+            self.act_ids.append(hits[0])
+
+    def reset(
+        self, rng: np.random.Generator, joint_jitter: float = 0.05, soft_limits=None
+    ):
+        """Match the task's reset events: jitter, CLAMPED to soft limits.
+
+        The clamp is not cosmetic. mjlab's reset_joints_by_offset clamps the
+        jittered position to the soft joint limits; a replica without it starts
+        episodes mjlab never generates. Measured: omitting the clamp produced a
+        9.4-point apparent sim-to-sim gap, while a paired test from identical
+        initial states showed 100% agreement between the two backends.
+        """
+        mujoco.mj_resetDataKeyframe(self.m, self.d, 0)
+        for k, adr in enumerate(self.b.robot_qpos_adr):
+            self.d.qpos[adr] += rng.uniform(-joint_jitter, joint_jitter)
+            if soft_limits is not None:
+                lo, hi = soft_limits[k]
+                self.d.qpos[adr] = min(max(self.d.qpos[adr], lo), hi)
+        # reset_door: offset in [0, 0.05], matching the task's event
+        self.d.qpos[self.b.door_qpos_adr] = self.b.default_qpos[
+            self.b.door_qpos_adr
+        ] + rng.uniform(0.0, 0.05)
+        self.d.qvel[:] = 0.0
+        self.d.ctrl[:] = self.b.default_ctrl
+        mujoco.mj_forward(self.m, self.d)
+        self.last_action = np.zeros(8, dtype=np.float32)
+        self.start_angle = float(self.d.qpos[self.b.door_qpos_adr])
+        self.prev_angle = self.start_angle
+        self.gained_contact = 0.0
+
+    def _contact(self) -> float:
+        return 1.0 if any(self.d.sensordata[a] > 0 for a in self.b.sensor_adr) else 0.0
+
+    def step(self, scale: np.ndarray, offset: np.ndarray):
+        """Advance one control step and return (observation, angle, contact)."""
+        obs = self.b.build(self.d, self.last_action)
+        action = self.sess.run(None, {self.in_name: obs[None, :].astype(np.float32)})[
+            0
+        ][0]
+        action = np.clip(action, -100.0, 100.0)
+        self.last_action = action.astype(np.float32)
+        target = offset + scale * action
+        for k, a in enumerate(self.act_ids):
+            self.d.ctrl[a] = target[k]
+        for _ in range(self.decimation):
+            mujoco.mj_step(self.m, self.d)
+
+        angle = float(self.d.qpos[self.b.door_qpos_adr])
+        contact = self._contact()
+        self.gained_contact += max(angle - self.prev_angle, 0.0) * contact
+        self.prev_angle = angle
+        return obs, angle, contact
+
+    def succeeded(self) -> bool:
+        """Return True when the task's own success criterion is satisfied."""
+        angle = float(self.d.qpos[self.b.door_qpos_adr])
+        gained = max(angle - self.start_angle, 0.0)
+        rate = abs(float(self.d.qvel[self.m.jnt_dofadr[self.b.door_joint]]))
+        return bool(
+            gained >= TARGET_SWING
+            and self.gained_contact >= HONEST_FRAC * TARGET_SWING
+            and rate < MAX_SWING_RATE
+            and self._contact() > 0
+        )

--- a/src/openarm_mjlab/tasks/families/__init__.py
+++ b/src/openarm_mjlab/tasks/families/__init__.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Procedurally generated task families.
+
+A *family* is one task type whose scene geometry is parameterised, so a single
+hand-written task yields many instances. Instances of a family share one
+observation layout, one action space and one policy head, and carry NO
+per-instance identity signal: the policy has to read the geometry out of the
+observations it already receives. That is what makes a held-out instance a real
+generalisation test rather than a lookup -- an identity one-hot would leave a
+held-out instance with no head to route to, and memorising N instances would
+score as well as understanding them.
+"""
+
+from mjlab.tasks.registry import register_mjlab_task
+from openarm_mjlab.tasks.door.rl_cfg import openarm_door_ppo_runner_cfg
+from openarm_mjlab.tasks.families.door_family import door_family_env_cfg
+from openarm_mjlab.tasks.families.door_split import (
+    assert_split_is_honest as assert_door_split_is_honest,
+)
+from openarm_mjlab.tasks.families.door_split import build_split as build_door_split
+from openarm_mjlab.tasks.families.valve_family import valve_family_env_cfg
+from openarm_mjlab.tasks.families.valve_split import (
+    assert_split_is_honest as assert_valve_split_is_honest,
+)
+from openarm_mjlab.tasks.families.valve_split import build_split as build_valve_split
+from openarm_mjlab.tasks.valve.rl_cfg import openarm_valve_ppo_runner_cfg
+
+N_TRAIN = 8
+N_HELD_OUT = 8
+
+VALVE_SPLIT = build_valve_split(
+    n_train=N_TRAIN, n_interp=N_HELD_OUT, n_extrap=N_HELD_OUT, seed=0
+)
+assert_valve_split_is_honest(VALVE_SPLIT)
+DOOR_SPLIT = build_door_split(
+    n_train=N_TRAIN, n_interp=N_HELD_OUT, n_extrap=N_HELD_OUT, seed=0
+)
+assert_door_split_is_honest(DOOR_SPLIT)
+
+VALVE_INSTANCE_IDS: dict[str, list[str]] = {"train": [], "interp": [], "extrap": []}
+DOOR_INSTANCE_IDS: dict[str, list[str]] = {"train": [], "interp": [], "extrap": []}
+
+
+def _register(prefix, split, ids, builder, rl_cfg):
+    for group, instances in split.items():
+        for params in instances:
+            task_id = f"{prefix}-{group}-{params.name()}"
+            ids[group].append(task_id)
+            register_mjlab_task(
+                task_id=task_id,
+                env_cfg=builder(params),
+                play_env_cfg=builder(params, play=True),
+                rl_cfg=rl_cfg(),
+            )
+
+
+_register(
+    "OpenArm-ValveFamily",
+    VALVE_SPLIT,
+    VALVE_INSTANCE_IDS,
+    valve_family_env_cfg,
+    openarm_valve_ppo_runner_cfg,
+)
+_register(
+    "OpenArm-DoorFamily",
+    DOOR_SPLIT,
+    DOOR_INSTANCE_IDS,
+    door_family_env_cfg,
+    openarm_door_ppo_runner_cfg,
+)

--- a/src/openarm_mjlab/tasks/families/door_family.py
+++ b/src/openarm_mjlab/tasks/families/door_family.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Door family: the hinged door with parameterised geometry.
+
+Structurally different from the valve family -- a hinged panel with a
+stand-off handle, rather than a lever rotating on its own axis -- which is
+what makes it a test of the GENERATOR rather than a second valve.
+
+Varied per instance:
+
+* ``handle_span`` -- distance from the hinge to the handle along the panel.
+  The substantive axis, matching ``lever_reach``'s role in the valve family:
+  it moves where the hand must go AND sets the moment arm about the hinge.
+  The panel is resized with it so the handle stays at the panel's outer edge.
+* ``standoff`` -- how far the handle stands proud of the panel face. Changes
+  how much room the gripper has to close around it.
+* ``x``, ``y``, ``height`` -- where the fixture sits.
+* ``damping`` -- hinge damping; deliberately unobservable, a robustness axis.
+
+NOMINAL reproduces the MERGED UPSTREAM door geometry, not this repo's copy.
+This repo still has the pre-review handle: a cylinder of radius 7mm centred in
+a panel of half-thickness 6mm, so it protruded 1mm from each face and a
+parallel gripper could not close around it. Building a family on that would
+inherit the defect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import mujoco
+
+from mjlab.entity import EntityCfg
+from openarm_mjlab.tasks.door.door_env_cfg import openarm_door_env_cfg
+
+_PANEL_HALF_THICKNESS = 0.006
+_PANEL_INSET = 0.015  # gap between hinge and panel's inner edge
+_PANEL_OVERHANG = -0.005  # panel ends 5mm PAST the handle
+
+
+@dataclass(frozen=True)
+class DoorParams:
+    """One instance of the door family."""
+
+    handle_span: float = 0.13
+    standoff: float = 0.030
+    x: float = 0.29
+    y: float = -0.10
+    height: float = 0.40
+    damping: float = 0.2
+
+    def name(self) -> str:
+        """Return a short stable id, used in the registered task id."""
+        return (
+            f"s{round(self.handle_span * 1000):03d}"
+            f"o{round(self.standoff * 1000):02d}"
+            f"x{round(self.x * 1000):03d}"
+            f"y{round(self.y * 1000):+04d}"
+            f"h{round(self.height * 1000):03d}"
+            f"d{round(self.damping * 100):03d}"
+        )
+
+
+NOMINAL = DoorParams()
+
+
+def make_door_spec(params: DoorParams):
+    """Return a zero-arg spec builder for one instance's geometry."""
+
+    def _spec() -> mujoco.MjSpec:
+        spec = mujoco.MjSpec()
+        spec.modelname = "door_fixture"
+        spec.compiler.degree = False
+
+        base = spec.worldbody.add_body(name="door_base")
+        base.add_geom(
+            name="table_top",
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(0.41, 0.55, 0.04),
+            pos=(0.47 - params.x, -params.y, 0.36 - params.height),
+            rgba=(0.82, 0.71, 0.55, 1.0),
+            friction=(1.0, 0.005, 0.0001),
+        )
+        base.add_geom(
+            name="door_post",
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(0.007, 0.007, 0.06),
+            pos=(0, -0.07, 0.06),
+            rgba=(0.4, 0.4, 0.45, 1.0),
+            friction=(1.0, 0.01, 0.01),
+        )
+
+        door = base.add_body(name="door", pos=(0, -0.07, 0.06))
+        door.add_joint(
+            name="door_hinge",
+            type=mujoco.mjtJoint.mjJNT_HINGE,
+            axis=(0, 0, 1),
+            range=(0.0, 1.4),
+            damping=params.damping,
+            frictionloss=0.02,
+        )
+        # The panel runs from the hinge out to just past the handle, so widening
+        # the span widens the door rather than leaving the handle floating past
+        # its edge. Upstream's panel starts 15mm from the hinge and ends 5mm past
+        # the handle; keeping both offsets reproduces it exactly at the nominal
+        # 130mm span (half 0.060, centre 0.075).
+        panel_half = (params.handle_span - _PANEL_INSET - _PANEL_OVERHANG) / 2.0
+        door.add_geom(
+            name="door_panel",
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(_PANEL_HALF_THICKNESS, panel_half, 0.05),
+            pos=(0, _PANEL_INSET + panel_half, 0),
+            mass=0.08,
+            rgba=(0.55, 0.45, 0.3, 1.0),
+        )
+        handle_y = params.handle_span
+        handle_x = -(_PANEL_HALF_THICKNESS + params.standoff)
+        door.add_geom(
+            name="door_handle",
+            type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+            fromto=(handle_x, handle_y, -0.025, handle_x, handle_y, 0.025),
+            size=(0.007, 0, 0),
+            mass=0.02,
+            rgba=(0.2, 0.2, 0.22, 1.0),
+            priority=2,
+            condim=3,
+            friction=(1.0, 0.01, 0.01),
+            solref=(0.005, 1.0),
+        )
+        for z in (-0.02, 0.02):
+            door.add_geom(
+                name=f"door_handle_post_{'hi' if z > 0 else 'lo'}",
+                type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+                fromto=(-_PANEL_HALF_THICKNESS, handle_y, z, handle_x, handle_y, z),
+                size=(0.004, 0, 0),
+                mass=0.005,
+                rgba=(0.2, 0.2, 0.22, 1.0),
+            )
+        door.add_site(
+            name="handle_site", pos=(handle_x, handle_y, 0), size=(0.005, 0, 0)
+        )
+        return spec
+
+    return _spec
+
+
+def door_family_env_cfg(params: DoorParams, play: bool = False):
+    """Return the door task rebuilt with one instance's geometry."""
+    cfg = openarm_door_env_cfg(play=play)
+    door_init = EntityCfg.InitialStateCfg(
+        pos=(params.x, params.y, params.height),
+        joint_pos={"door_hinge": 0.0},
+        joint_vel={"door_hinge": 0.0},
+    )
+    cfg.scene.entities["door"] = EntityCfg(
+        spec_fn=make_door_spec(params), init_state=door_init
+    )
+    return cfg
+
+
+def perturbed(base: DoorParams, **kwargs) -> DoorParams:
+    """Return a copy of ``base`` with the named fields replaced."""
+    return replace(base, **kwargs)

--- a/src/openarm_mjlab/tasks/families/door_split.py
+++ b/src/openarm_mjlab/tasks/families/door_split.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Instance sampling and held-out split for the door family.
+
+Same protocol as the valve family: split by parameter REGION rather than a
+random shuffle, reserve a band of the substantive axis that no training
+instance occupies, and put the extrapolation set strictly beyond everything
+trained. Interp and extrap are reported separately.
+"""
+
+from __future__ import annotations
+
+import random
+
+from openarm_mjlab.tasks.families.door_family import DoorParams
+
+# handle_span sets both where the hand must go and the moment arm about the
+# hinge, so the split is organised around it. Nominal upstream is 130mm.
+TRAIN_SPAN_LOW = (0.095, 0.118)
+INTERP_SPAN = (0.124, 0.140)  # reserved: no training instance here
+TRAIN_SPAN_HIGH = (0.146, 0.175)
+EXTRAP_SPAN = (0.190, 0.225)  # beyond every trained value
+
+# Note: unlike the valve family, these nuisance axes are sampled independently
+# per group rather than stratified, so their group means differ by up to about
+# a fifth of their range. That is left as-is deliberately: the published door
+# results were measured on exactly this split, and their three-seed
+# reproducibility on held-out instances (60.0 +- 0.20) shows the residual
+# imbalance is not driving the result. Stratifying here, as valve_split does,
+# would change the instances and require those runs to be repeated.
+STANDOFF_RANGE = (0.024, 0.038)
+X_RANGE = (0.265, 0.315)
+Y_RANGE = (-0.125, -0.075)
+HEIGHT_RANGE = (0.380, 0.420)
+DAMPING_RANGE = (0.12, 0.30)
+
+
+def _sample(rng: random.Random, span_range: tuple[float, float]) -> DoorParams:
+    return DoorParams(
+        handle_span=rng.uniform(*span_range),
+        standoff=rng.uniform(*STANDOFF_RANGE),
+        x=rng.uniform(*X_RANGE),
+        y=rng.uniform(*Y_RANGE),
+        height=rng.uniform(*HEIGHT_RANGE),
+        damping=rng.uniform(*DAMPING_RANGE),
+    )
+
+
+def build_split(
+    n_train: int = 8, n_interp: int = 8, n_extrap: int = 8, seed: int = 0
+) -> dict[str, list[DoorParams]]:
+    """Return disjoint train / interp / extrap instance lists."""
+    # Separate generators per group. With one shared generator the held-out sets
+    # shift whenever n_train changes, which would make a density experiment
+    # (same range, more training instances) compare against a moving target. The
+    # held-out geometry must be IDENTICAL across those runs for the comparison
+    # to mean anything.
+    train_rng = random.Random(seed)
+    interp_rng = random.Random(seed + 1_000)
+    extrap_rng = random.Random(seed + 2_000)
+    train = []
+    for i in range(n_train):
+        band = TRAIN_SPAN_LOW if i % 2 == 0 else TRAIN_SPAN_HIGH
+        train.append(_sample(train_rng, band))
+    interp = [_sample(interp_rng, INTERP_SPAN) for _ in range(n_interp)]
+    extrap = [_sample(extrap_rng, EXTRAP_SPAN) for _ in range(n_extrap)]
+    return {"train": train, "interp": interp, "extrap": extrap}
+
+
+def assert_split_is_honest(split: dict[str, list[DoorParams]]) -> None:
+    """Fail loudly if the split does not actually hold anything out."""
+    trained = [p.handle_span for p in split["train"]]
+    lo, hi = min(trained), max(trained)
+    for p in split["interp"]:
+        if not (lo < p.handle_span < hi):
+            raise ValueError(
+                f"interp span {p.handle_span:.4f} is outside the trained span "
+                f"[{lo:.4f}, {hi:.4f}] -- that is extrapolation, not interpolation"
+            )
+        if any(abs(p.handle_span - t) < 1e-6 for t in trained):
+            raise ValueError(f"interp span {p.handle_span:.4f} was trained on")
+    for p in split["extrap"]:
+        if p.handle_span <= hi:
+            raise ValueError(
+                f"extrap span {p.handle_span:.4f} is within the trained span "
+                f"(max {hi:.4f}) -- it is not extrapolation"
+            )
+    names = [q.name() for group in split.values() for q in group]
+    if len(names) != len(set(names)):
+        raise ValueError("duplicate instances across the split")
+
+
+def nominal_distance(params) -> float:
+    """Return |handle_span - the hand-written task's 130mm|, in metres.
+
+    Lets a single-geometry control's score be read against how far each
+    instance sits from the geometry it was actually trained on.
+    """
+    return abs(params.handle_span - 0.130)

--- a/src/openarm_mjlab/tasks/families/valve_family.py
+++ b/src/openarm_mjlab/tasks/families/valve_family.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Valve family: the lever valve with parameterised geometry.
+
+Varied per instance:
+
+* ``lever_reach`` -- distance from the hinge axis to the grip. This is the
+  substantive one. It moves where the policy must put its hand AND changes
+  the moment arm, so a short lever needs more force for the same torque. It
+  is observable through ``ee_to_grip``, which is what makes generalising to
+  an unseen reach possible at all.
+* ``x``, ``y``, ``height`` -- where the fixture sits.
+* ``damping`` -- hinge damping. Deliberately NOT observable; this is a
+  robustness axis, like domain randomisation, not something to infer.
+
+NOMINAL reproduces the hand-written task's GEOMETRY exactly -- every geom size
+and position is bit-identical, verified by diag_family_nominal.py -- with one
+deliberate difference: the grip carries the contact-priority fix (priority=2),
+without which the finger geoms outrank it and MuJoCo never reads its friction,
+so the task's own dr_grip_friction would randomise a value with no effect. The
+merged upstream valve has that fix; this repo's copy predates it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import mujoco
+
+from mjlab.entity import EntityCfg
+from openarm_mjlab.tasks.valve.valve_env_cfg import openarm_valve_env_cfg
+
+# The hand-written task puts the lever box half-length and centre at 0.035
+# with the grip at 0.062, i.e. both at 0.5645 * reach. Keeping that ratio
+# means NOMINAL rebuilds the original geometry bit for bit.
+_LEVER_RATIO = 0.035 / 0.062
+
+
+@dataclass(frozen=True)
+class ValveParams:
+    """One instance of the valve family."""
+
+    lever_reach: float = 0.062
+    x: float = 0.25
+    y: float = 0.0
+    height: float = 0.40
+    damping: float = 0.5
+
+    def name(self) -> str:
+        """Return a short stable id, used in the registered task id."""
+        return (
+            f"r{round(self.lever_reach * 1000):03d}"
+            f"x{round(self.x * 1000):03d}"
+            f"y{round(self.y * 1000):+04d}"
+            f"h{round(self.height * 1000):03d}"
+            f"d{round(self.damping * 100):03d}"
+        )
+
+
+NOMINAL = ValveParams()
+
+
+def make_valve_spec(params: ValveParams):
+    """Return a zero-arg spec builder for one instance's geometry."""
+
+    def _spec() -> mujoco.MjSpec:
+        spec = mujoco.MjSpec()
+        spec.modelname = "valve_fixture"
+        # Programmatic MjSpec defaults to DEGREES; the hinge range is radians.
+        spec.compiler.degree = False
+
+        base = spec.worldbody.add_body(name="valve_base")
+        base.add_geom(
+            name="table_top",
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(0.41, 0.55, 0.04),
+            pos=(0.47 - params.x, -params.y, 0.36 - params.height),
+            rgba=(0.82, 0.71, 0.55, 1.0),
+            friction=(1.0, 0.005, 0.0001),
+        )
+        base.add_geom(
+            name="valve_pipe",
+            type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+            size=(0.015, 0.0275, 0),
+            pos=(0, 0, 0.0275),
+            rgba=(0.4, 0.4, 0.45, 1.0),
+            friction=(1.0, 0.01, 0.01),
+        )
+
+        valve = base.add_body(name="valve", pos=(0, 0, 0.065))
+        valve.add_joint(
+            name="valve_turn",
+            type=mujoco.mjtJoint.mjJNT_HINGE,
+            axis=(0, 0, 1),
+            range=(-3.0, 3.0),
+            damping=params.damping,
+            frictionloss=0.05,
+        )
+        valve.add_geom(
+            name="valve_hub",
+            type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+            fromto=(0, 0, -0.006, 0, 0, 0.006),
+            size=(0.014, 0, 0),
+            mass=0.05,
+            rgba=(0.3, 0.3, 0.35, 1.0),
+        )
+        lever = _LEVER_RATIO * params.lever_reach
+        valve.add_geom(
+            name="valve_lever",
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=(lever, 0.008, 0.006),
+            pos=(lever, 0, 0),
+            mass=0.05,
+            rgba=(0.7, 0.2, 0.2, 1.0),
+        )
+        valve.add_geom(
+            name="valve_grip",
+            type=mujoco.mjtGeom.mjGEOM_CYLINDER,
+            fromto=(params.lever_reach, 0, -0.02, params.lever_reach, 0, 0.02),
+            size=(0.007, 0, 0),
+            mass=0.02,
+            rgba=(0.2, 0.2, 0.22, 1.0),
+            # Same contact-priority fix the hand-written tasks needed: the finger
+            # geoms are priority=1, so a default-priority grip is outranked and its
+            # friction is never read.
+            priority=2,
+            condim=3,
+            friction=(1.0, 0.01, 0.01),
+            solref=(0.005, 1.0),
+        )
+        valve.add_site(
+            name="grip_site", pos=(params.lever_reach, 0, 0), size=(0.005, 0, 0)
+        )
+        return spec
+
+    return _spec
+
+
+def valve_family_env_cfg(params: ValveParams, play: bool = False):
+    """Return the valve task rebuilt with one instance's geometry.
+
+    Everything except the scene -- rewards, terminations, observations, events,
+    actions -- is taken unchanged from the hand-written task, so an instance
+    differs from it only in geometry.
+    """
+    cfg = openarm_valve_env_cfg(play=play)
+    valve_init = EntityCfg.InitialStateCfg(
+        pos=(params.x, params.y, params.height),
+        joint_pos={"valve_turn": 0.0},
+        joint_vel={"valve_turn": 0.0},
+    )
+    cfg.scene.entities["valve"] = EntityCfg(
+        spec_fn=make_valve_spec(params), init_state=valve_init
+    )
+    return cfg
+
+
+def perturbed(base: ValveParams, **kwargs) -> ValveParams:
+    """Return a copy of ``base`` with the named fields replaced."""
+    return replace(base, **kwargs)
+
+
+__all__ = [
+    "NOMINAL",
+    "ValveParams",
+    "make_valve_spec",
+    "perturbed",
+    "valve_family_env_cfg",
+]

--- a/src/openarm_mjlab/tasks/families/valve_split.py
+++ b/src/openarm_mjlab/tasks/families/valve_split.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Instance sampling and the held-out split for the valve family.
+
+The split is by PARAMETER REGION, not a random shuffle, because a random
+shuffle over a narrow range makes "generalisation" trivial -- held-out
+instances end up interpolating between near-identical neighbours and the
+headline number measures nothing. Three disjoint sets are produced:
+
+* ``train``    -- sampled from the training region.
+* ``interp``   -- inside the training region's parameter box, but from a
+                  reserved band of ``lever_reach`` that no training instance
+                  occupies. Tests filling a hole in the distribution.
+* ``extrap``   -- ``lever_reach`` strictly beyond anything trained on. Tests
+                  going outside it, which is the harder and more honest claim.
+
+Reporting interp and extrap separately matters: a policy can be good at one
+and useless at the other, and a single averaged number would hide that.
+"""
+
+from __future__ import annotations
+
+import random
+
+from openarm_mjlab.tasks.families.valve_family import ValveParams
+
+# lever_reach drives both where the hand must go and the moment arm, so it is
+# the axis the split is organised around. The reserved interpolation band sits
+# inside the trained span; the extrapolation band sits past its upper edge.
+TRAIN_REACH_LOW = (0.045, 0.058)
+INTERP_REACH = (0.060, 0.068)  # reserved: no training instance here
+# The hand-written valve's lever_reach is 62mm, which falls INSIDE the interp
+# band above. That is fine for the family (it never trains there) but it
+# flatters a single-geometry control, which is effectively being tested at its
+# own training point. INTERP_REACH_FAR is a second reserved band, still inside
+# the trained span but away from 62mm, so the control comparison is clean.
+INTERP_REACH_FAR = (0.0595, 0.0600)
+TRAIN_REACH_HIGH = (0.070, 0.090)
+EXTRAP_REACH = (0.095, 0.115)  # beyond every trained value
+
+# Nuisance axes, sampled from the same ranges everywhere so they cannot
+# confound the reach-based split.
+X_RANGE = (0.215, 0.285)
+Y_RANGE = (-0.05, 0.05)
+HEIGHT_RANGE = (0.375, 0.425)
+DAMPING_RANGE = (0.35, 0.75)
+
+
+def _stratified(lo: float, hi: float, n: int, rng: random.Random) -> list[float]:
+    """Return n values covering [lo, hi] evenly, one jittered draw per stratum.
+
+    Independent uniform draws per group let a nuisance axis distribute itself
+    unevenly by chance. Measured on the valve family: y correlates -0.481 with
+    success -- MORE strongly than lever_reach, the axis the split is built on --
+    and random sampling gave the interp group 12% of instances on the arm's own
+    side against the extrap group's 62%, making the supposedly harder group
+    easier on the factor that mattered most. Stratifying gives every group the
+    same nuisance distribution.
+    """
+    step = (hi - lo) / n
+    vals = [lo + step * (i + rng.random()) for i in range(n)]
+    rng.shuffle(vals)
+    return vals
+
+
+def _sample_group(
+    rng: random.Random, reach_range: tuple[float, float], n: int
+) -> list[ValveParams]:
+    """Return n instances whose NUISANCE axes are stratified across the group."""
+    reach = _stratified(*reach_range, n, rng)
+    xs = _stratified(*X_RANGE, n, rng)
+    ys = _stratified(*Y_RANGE, n, rng)
+    hs = _stratified(*HEIGHT_RANGE, n, rng)
+    ds = _stratified(*DAMPING_RANGE, n, rng)
+    return [
+        ValveParams(lever_reach=r, x=x, y=y, height=h, damping=d)
+        for r, x, y, h, d in zip(reach, xs, ys, hs, ds)
+    ]
+
+
+def build_split(
+    n_train: int = 8, n_interp: int = 2, n_extrap: int = 2, seed: int = 0
+) -> dict[str, list[ValveParams]]:
+    """Return disjoint train / interp / extrap instance lists.
+
+    ``seed`` fixes the instance set so a rerun evaluates the same geometry.
+    """
+    train_rng = random.Random(seed)
+    interp_rng = random.Random(seed + 1_000)
+    extrap_rng = random.Random(seed + 2_000)
+    half = n_train // 2
+    train = _sample_group(train_rng, TRAIN_REACH_LOW, half) + _sample_group(
+        train_rng, TRAIN_REACH_HIGH, n_train - half
+    )
+    interp = _sample_group(interp_rng, INTERP_REACH, n_interp)
+    extrap = _sample_group(extrap_rng, EXTRAP_REACH, n_extrap)
+    return {"train": train, "interp": interp, "extrap": extrap}
+
+
+def nominal_distance(params) -> float:
+    """Return |lever_reach - the hand-written task's 62mm|, in metres.
+
+    Used to report how close a held-out instance sits to the geometry a
+    single-geometry control was trained on, so its score can be read fairly.
+    """
+    return abs(params.lever_reach - 0.062)
+
+
+def assert_split_is_honest(split: dict[str, list[ValveParams]]) -> None:
+    """Fail loudly if the split does not actually hold anything out."""
+    trained = [p.lever_reach for p in split["train"]]
+    lo, hi = min(trained), max(trained)
+    for p in split["interp"]:
+        if not (lo < p.lever_reach < hi):
+            raise ValueError(
+                f"interp reach {p.lever_reach:.4f} is outside the trained span "
+                f"[{lo:.4f}, {hi:.4f}] -- that is extrapolation, not interpolation"
+            )
+        if any(abs(p.lever_reach - t) < 1e-6 for t in trained):
+            raise ValueError(f"interp reach {p.lever_reach:.4f} was trained on")
+    for p in split["extrap"]:
+        if p.lever_reach <= hi:
+            raise ValueError(
+                f"extrap reach {p.lever_reach:.4f} is within the trained span "
+                f"(max {hi:.4f}) -- it is not extrapolation"
+            )
+    names = [q.name() for group in split.values() for q in group]
+    if len(names) != len(set(names)):
+        raise ValueError("duplicate instances across the split")

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -87,3 +87,104 @@ def test_exported_scene_matches_the_mjlab_model(tmp_path, group):
             atol=1e-9,
         ), field
     env.close()
+
+
+def _tiny_policy(obs_dim: int = 12, action_dim: int = 4):
+    """A small MLPModel, exported the way the runner exports one."""
+    import torch
+    from rsl_rl.models import MLPModel
+    from tensordict import TensorDict
+
+    obs = TensorDict(
+        {"actor": torch.zeros(1, obs_dim), "critic": torch.zeros(1, obs_dim)},
+        batch_size=[1],
+    )
+    groups = {"actor": ["actor"], "critic": ["critic"]}
+    model = MLPModel(
+        obs,
+        groups,
+        "actor",
+        action_dim,
+        (16, 16),
+        "elu",
+        True,
+        {"class_name": "GaussianDistribution", "init_std": 1.0, "std_type": "scalar"},
+    )
+    model.eval()
+    return model
+
+
+def _write_exports(model, out_dir, obs_dim):
+    import torch
+
+    torch.jit.script(model.as_jit()).save(str(out_dir / "policy.pt"))
+    onnx_model = model.as_onnx(verbose=False)
+    onnx_model.eval()
+    torch.onnx.export(
+        onnx_model,
+        onnx_model.get_dummy_inputs(),
+        str(out_dir / "policy.onnx"),
+        export_params=True,
+        opset_version=18,
+        input_names=onnx_model.input_names,
+        output_names=onnx_model.output_names,
+    )
+
+
+def test_verify_accepts_an_export_that_matches(tmp_path):
+    """A faithful export round-trips through both files."""
+    import torch
+    from tensordict import TensorDict
+
+    from openarm_mjlab.deploy.export import verify_exported_policy
+
+    obs_dim = 12
+    model = _tiny_policy(obs_dim)
+    _write_exports(model, tmp_path, obs_dim)
+
+    torch.manual_seed(0)
+    observations = torch.randn(6, obs_dim)
+    with torch.no_grad():
+        expected = model(
+            TensorDict({"actor": observations, "critic": observations}, batch_size=[6])
+        )
+    deltas = verify_exported_policy(
+        expected.numpy().astype(np.float32),
+        observations.numpy().astype(np.float32),
+        tmp_path,
+    )
+    assert deltas["policy.pt"] <= 1e-5
+    assert deltas["policy.onnx"] <= 1e-3
+
+
+def test_verify_rejects_an_export_that_does_not_match(tmp_path):
+    """The guard has to fire when the file is not the policy it came from.
+
+    This is the failure it exists for: an export can be written successfully
+    and still compute something else, in which case nothing else in the
+    pipeline notices until the policy is driving hardware.
+    """
+    import torch
+    from tensordict import TensorDict
+
+    from openarm_mjlab.deploy.export import verify_exported_policy
+
+    obs_dim = 12
+    model = _tiny_policy(obs_dim)
+    _write_exports(model, tmp_path, obs_dim)
+
+    # Export one policy, then ask the check to reproduce a different one.
+    other = _tiny_policy(obs_dim)
+    torch.manual_seed(0)
+    observations = torch.randn(6, obs_dim)
+    with torch.no_grad():
+        wrong = other(
+            TensorDict({"actor": observations, "critic": observations}, batch_size=[6])
+        )
+
+    with pytest.raises(RuntimeError, match="does not reproduce the trained policy"):
+        verify_exported_policy(
+            wrong.numpy().astype(np.float32),
+            observations.numpy().astype(np.float32),
+            tmp_path,
+        )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for exporting a policy and its scene for use outside mjlab."""
+
+import numpy as np
+import pytest
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from openarm_mjlab.deploy.export import _merge_duplicate_default_classes
+
+
+def test_merge_collapses_a_default_class_nested_inside_itself():
+    """mjlab's scene export nests <default class="robot/main"> inside itself.
+
+    MuJoCo rejects a repeated class name, so without this the exported scene
+    does not load at all. Every child of the inner block must survive.
+    """
+    xml = (
+        "<mujoco><default>"
+        '<default class="a"><default class="x"/>'
+        '<default class="a"><default class="y"/><default class="z"/></default>'
+        "</default></default></mujoco>"
+    )
+    merged_xml, count = _merge_duplicate_default_classes(xml)
+    assert count == 1
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(merged_xml)
+    classes = [d.get("class") for d in root.iter("default")]
+    assert classes.count("a") == 1, "the repeat should be gone"
+    for kept in ("x", "y", "z"):
+        assert kept in classes, f"child {kept} was dropped by the merge"
+
+
+def test_merge_is_a_no_op_when_there_is_nothing_to_merge():
+    xml = '<mujoco><default><default class="a"/><default class="b"/></default></mujoco>'
+    merged_xml, count = _merge_duplicate_default_classes(xml)
+    assert count == 0
+    assert merged_xml == xml
+
+
+@pytest.mark.parametrize("group", ["train", "interp"])
+def test_exported_scene_matches_the_mjlab_model(tmp_path, group):
+    """A rewritten XML is only useful if it compiles to the same physics."""
+    import mujoco
+    from mjlab.envs import ManagerBasedRlEnv
+    from mjlab.tasks.registry import load_env_cfg
+    from openarm_mjlab.deploy.export import export_scene_self_contained
+    from openarm_mjlab.tasks.families import DOOR_INSTANCE_IDS
+
+    task_id = DOOR_INSTANCE_IDS[group][0]
+    out = tmp_path / group
+    export_scene_self_contained(task_id, out)
+
+    cfg = load_env_cfg(task_id)
+    cfg.scene.num_envs = 1
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    reference = env.sim.mj_model
+    exported = mujoco.MjModel.from_xml_path(str(out / "scene.xml"))
+
+    for field in ("nq", "nv", "njnt", "ngeom", "nbody", "nu", "nsensor"):
+        assert getattr(reference, field) == getattr(exported, field), field
+    for field in (
+        "geom_friction",
+        "geom_priority",
+        "geom_size",
+        "body_mass",
+        "jnt_range",
+        "dof_damping",
+        "geom_solref",
+    ):
+        assert np.allclose(
+            np.asarray(getattr(reference, field)),
+            np.asarray(getattr(exported, field)),
+            atol=1e-9,
+        ), field
+    env.close()

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the procedurally generated task families.
+
+Note: building an env compiles mujoco-warp CPU kernels; the first run can take
+a few minutes.
+"""
+
+import pytest
+import torch
+
+import openarm_mjlab.tasks  # noqa: F401  # Registers tasks.
+from mjlab.tasks.registry import list_tasks, load_env_cfg
+from openarm_mjlab.tasks.families import (
+    DOOR_INSTANCE_IDS,
+    DOOR_SPLIT,
+    VALVE_INSTANCE_IDS,
+    VALVE_SPLIT,
+)
+from openarm_mjlab.tasks.families import door_split, valve_split
+from openarm_mjlab.tasks.families.door_family import (
+    NOMINAL as DOOR_NOMINAL,
+)
+from openarm_mjlab.tasks.families.door_family import (
+    door_family_env_cfg,
+)
+from openarm_mjlab.tasks.families.valve_family import (
+    NOMINAL as VALVE_NOMINAL,
+)
+from openarm_mjlab.tasks.families.valve_family import (
+    valve_family_env_cfg,
+)
+
+FAMILIES = (
+    ("valve", VALVE_SPLIT, VALVE_INSTANCE_IDS, valve_split, "lever_reach"),
+    ("door", DOOR_SPLIT, DOOR_INSTANCE_IDS, door_split, "handle_span"),
+)
+
+
+@pytest.mark.parametrize("name,split,ids,module,axis", FAMILIES)
+def test_every_instance_is_registered(name, split, ids, module, axis):
+    registered = set(list_tasks())
+    for group, task_ids in ids.items():
+        assert task_ids, f"{name}/{group} registered nothing"
+        for task_id in task_ids:
+            assert task_id in registered, task_id
+
+
+@pytest.mark.parametrize("name,split,ids,module,axis", FAMILIES)
+def test_held_out_really_is_held_out(name, split, ids, module, axis):
+    """Interp sits inside the trained span but on no trained value; extrap outside."""
+    trained = [getattr(p, axis) for p in split["train"]]
+    low, high = min(trained), max(trained)
+    for params in split["interp"]:
+        value = getattr(params, axis)
+        assert low < value < high
+        assert all(abs(value - t) > 1e-6 for t in trained)
+    for params in split["extrap"]:
+        assert getattr(params, axis) > high
+
+
+@pytest.mark.parametrize("name,split,ids,module,axis", FAMILIES)
+def test_honesty_check_rejects_a_broken_split(name, split, ids, module, axis):
+    """The guard must actually fire; a check that cannot fail proves nothing."""
+    broken = {k: list(v) for k, v in split.items()}
+    broken["extrap"] = list(split["interp"])  # not beyond the trained span
+    with pytest.raises(ValueError):
+        module.assert_split_is_honest(broken)
+
+
+def test_valve_nuisance_axes_are_stratified():
+    """Valve stratifies its nuisance axes, so no axis may differ much by group.
+
+    This guards a real defect: on an earlier, independently sampled valve split
+    the lateral position y correlated -0.481 with success -- more strongly than
+    lever_reach, the axis the split is built on -- and landed 12% of the
+    interpolation group on the arm's own side against 62% of the extrapolation
+    group, making the supposedly harder group easier on what mattered most.
+
+    The door family does NOT stratify; see the note in door_split.
+    """
+    from openarm_mjlab.tasks.families import valve_split as module
+
+    ranges = {
+        "x": module.X_RANGE,
+        "y": module.Y_RANGE,
+        "height": module.HEIGHT_RANGE,
+        "damping": module.DAMPING_RANGE,
+    }
+    for field, (low, high) in ranges.items():
+        means = [
+            sum(getattr(p, field) for p in VALVE_SPLIT[g]) / len(VALVE_SPLIT[g])
+            for g in ("train", "interp", "extrap")
+        ]
+        spread = max(means) - min(means)
+        # Compare against the SAMPLING RANGE, not the mean: y is centred on zero,
+        # which makes a mean-relative tolerance meaningless.
+        assert spread < 0.05 * (high - low), f"valve.{field} differs by group: {means}"
+
+
+def test_valve_nominal_reproduces_the_hand_written_geometry():
+    _assert_same_geometry(
+        load_env_cfg("OpenArm-Valve"),
+        valve_family_env_cfg(VALVE_NOMINAL),
+        ("valve_hub", "valve_lever", "valve_grip"),
+    )
+
+
+def test_door_nominal_reproduces_the_hand_written_geometry():
+    _assert_same_geometry(
+        load_env_cfg("OpenArm-Door"),
+        door_family_env_cfg(DOOR_NOMINAL),
+        ("door_panel", "door_handle"),
+    )
+
+
+def _assert_same_geometry(hand_cfg, family_cfg, geom_suffixes):
+    import mujoco
+    from mjlab.envs import ManagerBasedRlEnv
+
+    def sizes(cfg):
+        cfg.scene.num_envs = 1
+        env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+        model = env.sim.mj_model
+        out = {}
+        for i in range(model.ngeom):
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, i) or ""
+            for suffix in geom_suffixes:
+                if name.endswith(suffix):
+                    out[suffix] = (
+                        tuple(round(float(v), 6) for v in model.geom_size[i]),
+                        tuple(round(float(v), 6) for v in model.geom_pos[i]),
+                    )
+        env.close()
+        return out
+
+    hand, family = sizes(hand_cfg), sizes(family_cfg)
+    for suffix in geom_suffixes:
+        assert hand[suffix] == family[suffix], (
+            f"{suffix}: hand-written {hand[suffix]} vs family {family[suffix]}"
+        )
+
+
+@pytest.fixture(scope="module")
+def door_instance_env():
+    from mjlab.envs import ManagerBasedRlEnv
+
+    cfg = load_env_cfg(DOOR_INSTANCE_IDS["interp"][0])
+    cfg.scene.num_envs = 2
+    env = ManagerBasedRlEnv(cfg=cfg, device="cpu")
+    yield env
+    env.close()
+
+
+def test_instances_step_with_finite_signals(door_instance_env):
+    env = door_instance_env
+    env.reset()
+    for _ in range(5):
+        action = torch.zeros(2, env.action_manager.total_action_dim)
+        obs, rew, _, _, _ = env.step(action)
+        assert torch.isfinite(obs["actor"]).all()
+        assert torch.isfinite(rew).all()


### PR DESCRIPTION
Instead of hand-writing one valve and one door, this generates many of them by varying the geometry lever length, handle span, position, height, hinge damping. One policy trains on several at once, then gets tested on geometries it has never seen.

The policy is never told which instance it is facing, so it has to read the geometry from its observations rather than memorise a list. And the unseen instances come from a reserved band of lever lengths that no training instance occupies, rather than being sampled at random next to the training ones assert_split_is_honest() raises if that is ever violated.

Also adds a policy exporter. It writes an ONNX file plus the numbers a deployment target needs to use it (action scale and offset, actuator order, decimation, solver settings, joint limits), and a plain-MuJoCo runner that reads both. That runs on CPU with no mjlab and no GPU.

Results: trained on 8 door geometries, the policy solves unseen ones at 60.0% ± 0.2 over three seeds. A policy trained on a single geometry manages 45.1% on those same unseen instances. On the valve family it is 90.9% ± 3.4 (standard error) against 40.8%. On the longer-lever instances the idle arm can sit in the working arm's path
and stop it completing the turn. The quoted figures include those episodes as failures, so the family numbers are conservative rather than flattering.Pushed well past the trained range the family policy still beats the control every time, but the numbers vary too much between seeds to quote one. Each family's default settings rebuild the original hand-written task exactly. Running the exported policy in plain CPU MuJoCo gives the same outcome as mjlab on 48 of 48 episodes started from identical states; the rebuilt observations match mjlab to 4.9e-07 and the ONNX policy to 5.7e-06.
